### PR TITLE
alpine linux: add arm64 arch

### DIFF
--- a/templates/alpine.json
+++ b/templates/alpine.json
@@ -7,7 +7,8 @@
     "config_system": ["common"],
     "template_arch": {"amd64": "x86_64",
                       "i386": "x86",
-                      "armhf": "armhf"},
+                      "armhf": "armhf",
+                      "arm64": "arm64"},
     "template_args": ["-r", "RELEASE", "-a", "ARCH"],
     "post_create": []
 }


### PR DESCRIPTION
Please add arm64 arch for alpine linux
Signed-off-by: Alban Vidal alban.vidal@zordhak.fr