### PR TITLE
images: Change keyserver for Debian keys

### DIFF
--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -4,7 +4,7 @@ image:
 source:
   downloader: debootstrap
   url: http://deb.debian.org/debian
-  keyserver: hkps.pool.sks-keyservers.net
+  keyserver: keyserver.ubuntu.com
   keys:
     - 0x126C0D24BD8A2942CC7DF8AC7638D0442B90D010
     - 0xA1BD8E9D78F7FE5C3E65D8AF8B48AD6246925553


### PR DESCRIPTION
The previous keyserver seems to be missing some of the provided keys.
Updating the keyserver fixes the problem.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>