### PR TITLE
jenkins: Update openSUSE versions

### DIFF
--- a/jenkins/jobs/image-opensuse.yaml
+++ b/jenkins/jobs/image-opensuse.yaml
@@ -20,8 +20,8 @@
         name: release
         type: user-defined
         values:
+        - "15.1"
         - "15.0"
-        - "42.3"
         - "tumbleweed"
 
     - axis:


### PR DESCRIPTION
Add Leap 15.1, and remove Leap 42.3 as it has reached EOL.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>