### PR TITLE
jenkins/jobs: Remove Fedora 28 (EOL)

### DIFF
--- a/jenkins/jobs/image-fedora.yaml
+++ b/jenkins/jobs/image-fedora.yaml
@@ -20,7 +20,6 @@
         name: release
         type: user-defined
         values:
-        - 28
         - 29
         - 30
 


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>