### PR TITLE
jenkins: Disable some Gentoo cloud images

### DIFF
--- a/jenkins/jobs/image-gentoo.yaml
+++ b/jenkins/jobs/image-gentoo.yaml
@@ -35,6 +35,10 @@
         values:
         - lxc-priv
 
+    execution-strategy:
+      combination-filter: '
+      !(architecture!="amd64" && architecture!="i386" && variant=="cloud")'
+
     builders:
     - shell: |-
         cd /lxc-ci


### PR DESCRIPTION
Cloud-init is only supported on amd64 and x86 [0].

[0] https://packages.gentoo.org/packages/app-emulation/cloud-init

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>