### PR TITLE
jenkins: Don't build cloud images for Alpine

### DIFF
--- a/jenkins/jobs/image-alpine.yaml
+++ b/jenkins/jobs/image-alpine.yaml
@@ -32,7 +32,6 @@
         type: user-defined
         values:
         - default
-        - cloud
 
     - axis:
         name: restrict
@@ -53,8 +52,7 @@
         exec sudo /lxc-ci/bin/build-distro /lxc-ci/images/alpine.yaml \
             ${LXD_ARCHITECTURE} 600 ${WORKSPACE} \
             -o image.architecture=${ARCH} \
-            -o image.release=${release} \
-            -o image.variant=${variant}
+            -o image.release=${release}
 
     execution-strategy:
       combination-filter: '


### PR DESCRIPTION
Cloud-init is currently only available in the testing repo which needs
to be enabled explicitly.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>