### PR TITLE
Configure the hostname properly for gentoo hosts in /etc/conf.d/hostname.

### DIFF
--- a/images/gentoo.yaml
+++ b/images/gentoo.yaml
@@ -329,7 +329,8 @@ files:
 
  - name: conf-hostname
    path: /etc/conf.d/hostname
-   generator: hostname
+   generator: template
+   content: 'hostname="{{ container.name }}"'
 
  - name: hosts
    path: /etc/hosts


### PR DESCRIPTION
Having invalid configuration syntax in /etc/conf.d breaks the initial network setup in cloud-init.