### PR TITLE
Configure the hostname properly for gentoo hosts.

### DIFF
--- a/images/gentoo.yaml
+++ b/images/gentoo.yaml
@@ -329,7 +329,9 @@ files:
 
  - name: conf-hostname
    path: /etc/conf.d/hostname
-   generator: hostname
+   generator: template
+   content: |-
+     hostname="{{ container.name }}"
 
  - name: hosts
    path: /etc/hosts


### PR DESCRIPTION
Having invalid configuration syntax in /etc/conf.d breaks
the initial network setup. (in combination with cloud-init?)