### PR TITLE
gentoo: missing cloud scripts to the default runlevel

### DIFF
--- a/images/gentoo.yaml
+++ b/images/gentoo.yaml
@@ -415,7 +415,10 @@ actions:
    action: |-
      #!/bin/sh
      set -eux
+     rc-update add cloud-init-local default
      rc-update add cloud-init default
+     rc-update add cloud-config default
+     rc-update add cloud-final default
    variants:
      - cloud
 


### PR DESCRIPTION
We need all 4 scripts to be added to have a complete cloud-init run on gentoo.