### PR TITLE
images/debian: Also mask systemd-networkd-wait-online

### DIFF
--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -904,6 +904,7 @@ actions:
       # Disable networkd (unused)
       systemctl mask systemd-networkd.service
       systemctl mask systemd-networkd.socket
+      systemctl mask systemd-networkd-wait-online.service
 
       # Make sure the locale is built and functional
       echo en_US.UTF-8 UTF-8 >> /etc/locale.gen


### PR DESCRIPTION
After fixing the shutdown issue (#4939) by masking systemd-networkd
(c63ceec4), we should also mask the systemd-networkd-wait-online
service, otherwise things that depend on network-online.target may hang
for 2 minutes until the service times out.