### PR TITLE
jenkins/jobs: Use boot variant for CentOS 8

### DIFF
--- a/jenkins/jobs/image-centos.yaml
+++ b/jenkins/jobs/image-centos.yaml
@@ -54,7 +54,7 @@
         fi
 
         if [ "${release}" = "8" ]; then
-            EXTRA_ARGS="${EXTRA_ARGS} -o source.variant=dvd1"
+            EXTRA_ARGS="${EXTRA_ARGS} -o source.variant=boot"
         fi
 
         exec sudo /lxc-ci/bin/build-distro /lxc-ci/images/centos.yaml \


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>