### PR TITLE
images/oracle: Fix Oracle Linux 8 cloud image

### DIFF
--- a/images/oracle.yaml
+++ b/images/oracle.yaml
@@ -171,6 +171,21 @@ packages:
        action: install
        variants:
         - cloud
+
+    repositories:
+      - name: AppStream
+        url: |-
+          [AppStream]
+          name=Oracle Linux AppStream
+          baseurl=http://yum.oracle.com/repo/OracleLinux/OL{{ image.release }}/appstream/$basearch/
+          enabled=1
+          gpgcheck=1
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+        releases:
+          - 8
+        variants:
+          - cloud
+
 actions:
   - trigger: post-packages
     action: |-


### PR DESCRIPTION
This adds the AppStream repository for OL8 when building the cloud
image. This is required as the cloud-init package is in this repo.

This is blocked by https://github.com/lxc/distrobuilder/pull/255.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>