### PR TITLE
jobs: Don't build ALT Linux P9 on ppc64

### DIFF
--- a/jenkins/jobs/image-alt.yaml
+++ b/jenkins/jobs/image-alt.yaml
@@ -38,7 +38,7 @@
     execution-strategy:
       combination-filter: '
       !(architecture=="arm64" && release=="p8")
-      && !(architecture=="ppc64el" && release=="p8")'
+      && !(architecture=="ppc64el" && release!="Sisyphus")'
 
     builders:
     - shell: |-


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>