### PR TITLE
Archlinux has a base package now instead of a package group

### DIFF
--- a/images/archlinux.yaml
+++ b/images/archlinux.yaml
@@ -474,6 +474,7 @@ packages:
 
   sets:
     - packages:
+        - base
         - dhcpcd
         - diffutils
         - file


### PR DESCRIPTION
https://www.archlinux.org/news/base-group-replaced-by-mandatory-base-package-manual-intervention-required/