### PR TITLE
images/archlinux: Fix package section for ARM

### DIFF
--- a/images/archlinux.yaml
+++ b/images/archlinux.yaml
@@ -519,21 +519,11 @@ packages:
     - packages:
         - dnssec-anchors
         - haveged
-        - jfsutils
         - ldns
-        - libaio
         - libedit
         - linux-firmware
-        - lvm2
-        - mdadm
         - net-tools
         - openssh
-        - pciutils
-        - reiserfsprogs
-        - s-nail
-        - thin-provisioning-tools
-        - usbutils
-        - xfsprogs
       action: remove
       architectures:
         - aarch64


### PR DESCRIPTION
Don't attempt to remove not-installed packages as this causes pacman to
fail. This also removes pciutils from the list of packages which are to
be removed. The reason being that this package is required by the base
group, and removing it will cause problems.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>