### PR TITLE
Fully enable cloud-init on Fedora

### DIFF
--- a/images/fedora.yaml
+++ b/images/fedora.yaml
@@ -163,5 +163,7 @@ actions:
       systemctl disable systemd-networkd
       systemctl enable NetworkManager
       systemctl enable cloud-init
+      systemctl enable cloud-config
+      systemctl enable cloud-final
     variants:
       - cloud


### PR DESCRIPTION
This change enables the Config and Final boot stages of cloud-init on the cloud variant of the Fedora image. This is necessary for all the documented features of cloud-init to work, such as the "packages" and "runcmd" config keys.

Signed-off-by: Michael McCallister <mike@mccllstr.com>