### PR TITLE
images/openwrt: Ensure /var/lock

### DIFF
--- a/images/openwrt.yaml
+++ b/images/openwrt.yaml
@@ -403,6 +403,20 @@ actions:
       mkdir -p /var/lock
       echo "console::askfirst:/usr/libexec/login.sh" >> /etc/inittab
 
+  - trigger: post-unpack
+    action: |
+      #!/bin/sh
+      mkdir -p /var/lock
+    types:
+     - container
+
+  - trigger: post-unpack
+    action: |
+      #!/bin/sh
+      mkdir -p /var/lock
+    types:
+     - vm
+
 packages:
   manager: opkg
   update: false


### PR DESCRIPTION
This ensures that /var/lock is always present, especially when running
distrobuilder pack-lx{c,d}.
Due to /var being a symlink to /tmp which in turn is a tmpfs, the
directory /var/lock will never be persistent.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>