### PR TITLE
bin/build-image-distrobuilder: Allow access to loop partitions

### DIFF
--- a/bin/build-image-distrobuilder
+++ b/bin/build-image-distrobuilder
@@ -14,7 +14,8 @@ TARGET="$2"
 
 # Create the container
 lxc init "images:ubuntu/bionic/${ARCH}" build-distrobuilder-cache \
-    -c security.privileged=true -c security.nesting=true
+    -c security.privileged=true -c security.nesting=true \
+    -c raw.lxc="lxc.cgroup.devices.allow = b 259:* rw"
 
 # Setup loop devices
 (


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>