### PR TITLE
images/gentoo: Fix keyserver

### DIFF
--- a/images/gentoo.yaml
+++ b/images/gentoo.yaml
@@ -398,6 +398,23 @@ actions:
          echo pf:12345:powerwait:/sbin/halt >> /etc/inittab
      fi
 
+ - trigger: post-unpack
+   action: |-
+     #!/bin/sh
+     set -eux
+
+     # Workaround GPG issues
+     mv /usr/bin/gpg2 /usr/bin/gpg2.real
+     echo "#!/bin/sh" > /usr/bin/gpg2
+     echo "exec /usr/bin/gpg2.real --keyserver keyserver.ubuntu.com \"\$@\"" >> /usr/bin/gpg2
+     chmod +x /usr/bin/gpg2
+
+     cp /usr/share/portage/config/repos.conf /usr/share/portage/config/repos.conf.orig
+     sed -i "s#hkps://keys.gentoo.org#keyserver.ubuntu.com#g" /usr/share/portage/config/repos.conf
+   types:
+    - containers
+    - vm
+
  - trigger: post-packages
    action: |-
      #!/bin/sh
@@ -410,6 +427,19 @@ actions:
      mv /usr/bin/gpg2.real /usr/bin/gpg2
      rm /usr/share/portage/config/repos.conf
      mv /usr/share/portage/config/repos.conf.orig /usr/share/portage/config/repos.conf
+
+ - trigger: post-packages
+   action: |-
+     #!/bin/sh
+     set -eux
+
+     rm /usr/bin/gpg2
+     mv /usr/bin/gpg2.real /usr/bin/gpg2
+     rm /usr/share/portage/config/repos.conf
+     mv /usr/share/portage/config/repos.conf.orig /usr/share/portage/config/repos.conf
+   types:
+    - containers
+    - vm
 
  - trigger: post-packages
    action: |-


### PR DESCRIPTION
This fixes the keyserver when running `distrobuilder pack-lx{c,d}`.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>