### PR TITLE
images/archlinux: Only remove linux-firmware for containers

### DIFF
--- a/images/archlinux.yaml
+++ b/images/archlinux.yaml
@@ -586,13 +586,21 @@ packages:
         - haveged
         - ldns
         - libedit
-        - linux-firmware
         - net-tools
         - openssh
       action: remove
       architectures:
         - aarch64
         - armv7
+
+    - packages:
+        - linux-firmware
+      action: remove
+      architectures:
+        - aarch64
+        - armv7
+      types:
+        - container
 
 actions:
   - trigger: post-packages


### PR DESCRIPTION
Since linux-firmware is a dependency of linux-aarch64, removing it would
remove the kernel and mkinitcpio which in turn would leave us without an
initramfs.
Therefore, only remove linux-firmware for containers.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>