### PR TITLE
images/archlinux: Don't remove linux-firmware twice

### DIFF
--- a/images/archlinux.yaml
+++ b/images/archlinux.yaml
@@ -598,7 +598,6 @@ packages:
       action: remove
       architectures:
         - aarch64
-        - armv7
       types:
         - container
 


### PR DESCRIPTION
Since linux-firmware is automatically removed when removing the linux
package, don't attempt to remove it a second time as this will fail.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>