### PR TITLE
images/archlinux: Exclude fallback initramfs

### DIFF
--- a/images/archlinux.yaml
+++ b/images/archlinux.yaml
@@ -627,12 +627,10 @@ actions:
       # Rebuild initrd
       sed -i 's#^MODULES=.*#MODULES=(virtio_pci virtio_scsi virtio_console)#' /etc/mkinitcpio.conf
 
-      if [ "${TARGET}" = "x86_64" ]; then
-        mkinitcpio -p linux
-      else
-        mkinitcpio -p linux-$(uname -m)
-      fi
+      sed -i 's#^PRESETS=.*#PRESETS=(default)#' /etc/mkinitcpio.d/*.preset
+      mkinitcpio -P
     types:
       - vm
+
 mappings:
   architecture_map: archlinux


### PR DESCRIPTION
This excludes the fallback initramfs. It's usually not needed and
currently causes some issues when building it.

Also, use `mkinicpio -P` which simply considers all preset files.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>