### PR TITLE
images/opensuse: Fix shim for aarch64

### DIFF
--- a/images/opensuse.yaml
+++ b/images/opensuse.yaml
@@ -179,6 +179,7 @@ packages:
        - aarch64
 
     - packages:
+       - shim
        - grub2-x86_64-efi
       action: install
       types:
@@ -188,7 +189,6 @@ packages:
 
     - packages:
        - kernel-default
-       - shim
       action: install
       types:
        - vm


### PR DESCRIPTION
Shim is amd64 only.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>