### PR TITLE
images/centos: Use NetworkManager on CentOS 7 VM

### DIFF
--- a/images/centos.yaml
+++ b/images/centos.yaml
@@ -566,6 +566,14 @@ packages:
     - 8-Stream
 
   - packages:
+    - NetworkManager
+    action: install
+    releases:
+    - 7
+    types:
+    - vm
+
+  - packages:
     - cloud-init
     action: install
     variants:


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>