### PR TITLE
images: Add acpid to VM images

### DIFF
--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -959,6 +959,15 @@ packages:
     - cloud
 
   - packages:
+    - acpid
+    action: install
+    architectures:
+    - amd64
+    - arm64
+    types:
+    - vm
+
+  - packages:
     - grub-efi
     action: install
     types:

--- a/images/ubuntu.yaml
+++ b/images/ubuntu.yaml
@@ -427,6 +427,15 @@ packages:
     - cloud
 
   - packages:
+    - acpid
+    action: install
+    architectures:
+    - amd64
+    - arm64
+    types:
+    - vm
+
+  - packages:
     - grub-efi-amd64-signed
     - shim-signed
     action: install


### PR DESCRIPTION
This adds acpid to Debian and Ubuntu VM images which resolves shutdown
issues.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>