### PR TITLE
Revert "jenkins/jobs: Add Apertis v2019.3"

### DIFF
--- a/jenkins/jobs/image-apertis.yaml
+++ b/jenkins/jobs/image-apertis.yaml
@@ -18,7 +18,7 @@
         name: release
         type: user-defined
         values:
-        - 'v2019.3'
+        - 'v2019.2'
         - 'v2020.0'
 
     - axis:


### PR DESCRIPTION
This reverts commit d53e606371a943c635099943e44d8a6c9ceefeb5.

Currently, the only available images for v2019.3 are the rc3 ones
which we don't support.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
