### PR TITLE
Add init script to emerge --sync at first boot.

### DIFF
--- a/images/gentoo.yaml
+++ b/images/gentoo.yaml
@@ -343,6 +343,14 @@ files:
     rc_keyword="-stop"
     config_eth0="dhcp"
 
+- path: /etc/local.d/repo_check.start
+  generator: dump
+  mode: 700
+  content: |-
+    #!/bin/bash
+    filename="header.txt"
+    test -f $(portageq get_repo_path / gentoo)/$filename || emerge --sync; chmod -x /etc/local.d/repo_check.start
+
 - name: meta-data
   generator: cloud-init
   variants:


### PR DESCRIPTION
Here is my attempt at solving the problem. I was unable to create a working image on my system, distrobuilder fails with errors.

I get this output:

```
# /usr/local/bin/distrobuilder build-lxd gentoo.yaml 
+ mv /usr/bin/gpg2 /usr/bin/gpg2.real
+ echo '#!/bin/sh'
+ echo 'exec /usr/bin/gpg2.real --keyserver keyserver.ubuntu.com "$@"'
+ chmod +x /usr/bin/gpg2
+ cp /usr/share/portage/config/repos.conf /usr/share/portage/config/repos.conf.orig
+ sed -i s#hkps://keys.gentoo.org#keyserver.ubuntu.com#g /usr/share/portage/config/repos.conf
+ sed -ri 's#(sync-uri =) .+#\1 rsync://rsync.ca.gentoo.org/gentoo-portage/#' /usr/share/portage/config/repos.conf
+ '[' -e /etc/inittab ']'
+ sed -i 's/^c[0-9]:/#\0/' /etc/inittab
+ sed -i 's/^#\(x1:.*\)/\1/' etc/inittab
+ echo pf:12345:powerwait:/sbin/halt
+ mv /usr/bin/gpg2 /usr/bin/gpg2.real
+ echo '#!/bin/sh'
+ echo 'exec /usr/bin/gpg2.real --keyserver keyserver.ubuntu.com "$@"'
+ chmod +x /usr/bin/gpg2
+ cp /usr/share/portage/config/repos.conf /usr/share/portage/config/repos.conf.orig
+ sed -i s#hkps://keys.gentoo.org#keyserver.ubuntu.com#g /usr/share/portage/config/repos.conf
+ sed -ri 's#(sync-uri =) .+#\1 rsync://rsync.ca.gentoo.org/gentoo-portage/#' /usr/share/portage/config/repos.conf
++ uname -m
+ TARGET=x86_64
+ case "${TARGET}" in
+ TARGET=amd64
+ echo 'ACCEPT_KEYWORDS=~amd64'
+ ln -s net.lo /etc/init.d/net.eth0
+ mkdir -p /etc/runlevels/default
+ rc-update add net.eth0 default
 * service net.eth0 added to runlevel default
+ rm /usr/bin/gpg2
+ mv /usr/bin/gpg2.real /usr/bin/gpg2
+ rm /usr/share/portage/config/repos.conf
+ mv /usr/share/portage/config/repos.conf.orig /usr/share/portage/config/repos.conf
+ rm /usr/bin/gpg2
+ mv /usr/bin/gpg2.real /usr/bin/gpg2
mv: cannot stat '/usr/bin/gpg2.real': No such file or directory
Error: Failed to run post-packages: exit status 1
```

It looks like distrobuilder is executing both post-packages sections:
https://github.com/lxc/lxc-ci/blob/5865c94b68256463d2bceaf32c9437d1cf059aa1/images/gentoo.yaml#L469-L493

If I comment out the second one, I get this output:
```
# /usr/local/bin/distrobuilder build-lxd gentoo.yaml 
+ mv /usr/bin/gpg2 /usr/bin/gpg2.real
+ echo '#!/bin/sh'
+ echo 'exec /usr/bin/gpg2.real --keyserver keyserver.ubuntu.com "$@"'
+ chmod +x /usr/bin/gpg2
+ cp /usr/share/portage/config/repos.conf /usr/share/portage/config/repos.conf.orig
+ sed -i s#hkps://keys.gentoo.org#keyserver.ubuntu.com#g /usr/share/portage/config/repos.conf
+ sed -ri 's#(sync-uri =) .+#\1 rsync://rsync.ca.gentoo.org/gentoo-portage/#' /usr/share/portage/config/repos.conf
+ '[' -e /etc/inittab ']'
+ sed -i 's/^c[0-9]:/#\0/' /etc/inittab
+ sed -i 's/^#\(x1:.*\)/\1/' etc/inittab
+ echo pf:12345:powerwait:/sbin/halt
+ mv /usr/bin/gpg2 /usr/bin/gpg2.real
+ echo '#!/bin/sh'
+ echo 'exec /usr/bin/gpg2.real --keyserver keyserver.ubuntu.com "$@"'
+ chmod +x /usr/bin/gpg2
+ cp /usr/share/portage/config/repos.conf /usr/share/portage/config/repos.conf.orig
+ sed -i s#hkps://keys.gentoo.org#keyserver.ubuntu.com#g /usr/share/portage/config/repos.conf
+ sed -ri 's#(sync-uri =) .+#\1 rsync://rsync.ca.gentoo.org/gentoo-portage/#' /usr/share/portage/config/repos.conf
++ uname -m
+ TARGET=x86_64
+ case "${TARGET}" in
+ TARGET=amd64
+ echo 'ACCEPT_KEYWORDS=~amd64'
+ ln -s net.lo /etc/init.d/net.eth0
+ mkdir -p /etc/runlevels/default
+ rc-update add net.eth0 default
 * service net.eth0 added to runlevel default
+ rm /usr/bin/gpg2
+ mv /usr/bin/gpg2.real /usr/bin/gpg2
+ rm /usr/share/portage/config/repos.conf
+ mv /usr/share/portage/config/repos.conf.orig /usr/share/portage/config/repos.conf
Error: Failed to create overlay: no such device
```
