### PR TITLE
Remove ACCEPT_KEYWORDS from /etc/portage/make.conf

### DIFF
--- a/images/gentoo.yaml
+++ b/images/gentoo.yaml
@@ -469,7 +469,6 @@ actions:
       TARGET=arm ;;
     esac
 
-    echo ACCEPT_KEYWORDS="~${TARGET}" >> /etc/portage/make.conf
   types:
   - container
   - vm


### PR DESCRIPTION
Closes #187.

Signed-off-by: Stephen Bosch <posting@vodacomm.ca>