### PR TITLE
Enable dqlite engine V2 when running Jenkins tests

### DIFF
--- a/bin/build-lxd
+++ b/bin/build-lxd
@@ -166,6 +166,9 @@ if [ "$(uname -m)" != "x86_64" ]; then
     unset LXD_CEPH_CLUSTER
 fi
 
+# Enable dqlite engine V2 (TODO: drop this once V2 is the default)
+export DQLITE_ENGINE_V2=1
+
 # Run the unit tests
 if [ "${LXD_BACKEND}" = "dir" ]; then
     echo "==> UNIT BEGIN: all tests"


### PR DESCRIPTION
This setting should be kept for a bit, to make sure we don't see test regressions. After that we'll make V2 the default in dqlite and this setting can be dropped.