### PR TITLE
Adds test for LXD VMs

### DIFF
--- a/bin/test-lxd-vm
+++ b/bin/test-lxd-vm
@@ -1,0 +1,174 @@
+#!/bin/sh
+set -eux
+
+cleanup() {
+    echo ""
+    if [ "${FAIL}" = "1" ]; then
+        echo "Test failed"
+        exit 1
+    fi
+
+    echo "Test passed"
+    exit 0
+}
+
+poolDriverList="${1:-dir btrfs lvm zfs}"
+FAIL=1
+trap cleanup EXIT HUP INT TERM
+
+# Wait for snapd seeding
+sleep 1m
+
+# Configure to use the proxy
+curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh
+
+# Configure for ceph use
+curl -s http://canonical-lxd.stgraber.org/config/ceph.sh | sh
+
+# Install LXD
+while :; do
+    [ ! -e /usr/bin/lxd ] && break
+    apt remove --purge lxd lxd-client --yes && break
+done
+snap install lxd --edge
+snap install jq
+snap refresh lxd --channel=latest/edge
+lxd waitready --timeout=300
+
+# Configure LXD
+lxc network create lxdbr0
+lxc profile device add default eth0 nic network=lxdbr0
+
+for poolDriver in $poolDriverList
+do
+        echo "==> Create storage pool using driver ${poolDriver}"
+        if [ "${poolDriver}" = "dir" ]; then
+                lxc storage create vmpool "${poolDriver}"
+        else
+                lxc storage create vmpool "${poolDriver}" size=20GB
+        fi
+
+        echo "==> Create VM and boot"
+        lxc init images:ubuntu/20.04/cloud v1 --vm -s vmpool
+        lxc start v1
+        sleep 60
+        lxc info v1
+
+        echo "==> Checking VM root disk size is 10GB"
+        lxc exec v1 -- df -B1000000000 | grep sda2 | grep 10
+
+        echo "==> Increasing VM root disk size for next boot"
+        lxc config device set v1 root size=11GB
+        lxc config get v1 volatile.root.apply_quota | grep 11GB
+        lxc stop -f v1
+        lxc start v1
+        sleep 60
+
+        echo "==> Checking VM root disk size is 11GB"
+        lxc exec v1 -- df -B1000000000 | grep sda2 | grep 11
+
+        echo "==> Check VM shrink is blocked"
+        ! lxc config device set v1 root size=10GB || false
+
+        echo "==> Deleting VM"
+        lxc delete -f v1
+
+        echo "==> Change volume.size on pool and create VM"
+        lxc storage set vmpool volume.size 6GB
+        lxc init images:ubuntu/20.04/cloud v1 --vm -s vmpool
+        lxc start v1
+        sleep 60
+        lxc info v1
+
+        echo "==> Checking VM root disk size is 6GB"
+        lxc exec v1 -- df -B1000000000 | grep sda2 | grep 6
+
+        echo "==> Deleting VM and reset pool volume.size"
+        lxc delete -f v1
+        lxc storage unset vmpool volume.size
+
+        if [ "${poolDriver}" = "lvm" ]; then
+                echo "==> Change volume.block.filesystem on pool and create VM"
+                lxc storage set vmpool volume.block.filesystem xfs
+                lxc init images:ubuntu/20.04/cloud v1 --vm -s vmpool
+                lxc start v1
+                sleep 60
+                lxc info v1
+
+                echo "==> Checking VM config disk filesyste is XFS"
+                serverPID="$(lxc query /1.0 | jq .environment.server_pid)"
+                nsenter -m -t "${serverPID}" stat -f -c %T /var/snap/lxd/common/lxd/virtual-machines/v1 | grep xfs
+
+                echo "==> Deleting VM"
+                lxc delete -f v1
+                lxc storage unset vmpool volume.block.filesystem
+        fi
+
+        echo "==> Create VM from profile with small disk size"
+        lxc profile copy default vmsmall
+        lxc profile device add vmsmall root disk pool=vmpool path=/ size=7GB
+        lxc init images:ubuntu/20.04/cloud v1 --vm -p vmsmall
+        lxc start v1
+        sleep 60
+        lxc info v1
+
+        echo "==> Checking VM root disk size is 7GB"
+        lxc exec v1 -- df -B1000000000 | grep sda2 | grep 7
+        lxc stop -f v1
+
+        echo "==> Copy to different storage pool and check size"
+        dstPoolDriver=zfs # Use ZFS storage pool as that fixed volumes not files.
+        if [ "${poolDriver}" = "zfs" ]; then
+                dstPoolDriver=lvm # Use something different when testing ZFS.
+        fi
+
+        lxc storage create vmpool2 "${dstPoolDriver}" size=20GB
+        lxc copy v1 v2 -s vmpool2
+        lxc start v2
+        sleep 60
+        lxc info v2
+
+        echo "==> Checking copied VM root disk size is 7GB"
+        lxc exec v2 -- df -B1000000000 | grep sda2 | grep 7
+        lxc delete -f v2
+
+        echo "==> Grow above default voume size and copy to different storage pool"
+        lxc config device override v1 root size=11GB
+        lxc copy v1 v2 -s vmpool2
+        lxc start v2
+        sleep 60
+        lxc info v2
+
+        echo "==> Checking copied VM root disk size is 11GB"
+        lxc exec v2 -- df -B1000000000 | grep sda2 | grep 11
+        lxc delete -f v2
+
+        echo "==> Publishing larger VM"
+        lxc publish v1 --alias vmbig
+        lxc delete -f v1
+        lxc storage set vmpool volume.size 9GB
+
+        echo "==> Check VM create fails when image larger than volume.size"
+        ! lxc init vmbig v1 --vm -s vmpool || false
+
+        echo "==> Check VM create succeeds when no volume.size set"
+        lxc storage unset vmpool volume.size
+        lxc init vmbig v1 --vm -s vmpool
+        lxc start v1
+        sleep 60
+        lxc info v1
+
+        echo "==> Checking new VM root disk size is 11GB"
+        lxc exec v1 -- df -B1000000000 | grep sda2 | grep 11
+
+        echo "==> Deleting VM, vmbig image and vmsmall profile"
+        lxc delete -f v1
+        lxc image delete vmbig
+        lxc profile delete vmsmall
+
+        echo "==> Deleting storage pool"
+        lxc storage delete vmpool2
+        lxc storage delete vmpool
+done
+
+FAIL=0


### PR DESCRIPTION
There's a few more tests to add, but this adds most of them:

Runs the following tests for dir, btrfs, lvm and zfs:

- VM create.
- VM grow on next reboot.
- VM shrink prevented.
- VM create after storage volume.size changed.
- VM create after storage volume.block.filesystem changed.
- VM create from profile with disk smaller than default VM volume size.
- VM migrate across pools with disk size larger than volume.size.
- VM migrate across pools with disk size smaller than volume.size.
- Export VM larger than default size and import (with/without volume.size set).

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>