### PR TITLE
images/debian: add gpg to debian cloud variant for apt cloud-init module

### DIFF
--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -958,6 +958,7 @@ packages:
 
   - packages:
     - cloud-init
+    - gpg
     - resolvconf
     action: install
     variants:


### PR DESCRIPTION
gpg is a requirement for the cloud-init apt module to import keys natively.

This configuration will fail without gpg:

```yaml
#cloud-config
apt:
  sources:
    docker.list:
      source: deb [arch=amd64] https://download.docker.com/linux/debian $RELEASE stable
      keyid: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
```

Failure:

```
[71970.876146] cloud-init[242]: 2020-12-31 22:49:19,779 - util.py[WARNING]: Running module set-passwords (<module 'cloudinit.config.cc_set_passwords' from '/usr/lib/python3/dist-packages/cloudinit/config/cc_set_passwords.py'>) failed
[71972.973731] cloud-init[242]: 2020-12-31 22:49:21,876 - gpg.py[ERROR]: Failed to obtain gpg key 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
[71972.973827] cloud-init[242]: Traceback (most recent call last):
[71972.973868] cloud-init[242]:   File "/usr/lib/python3/dist-packages/cloudinit/gpg.py", line 61, in recv_key
[71972.973905] cloud-init[242]:     naplen = next(sleeps)
[71972.973942] cloud-init[242]: StopIteration
[71972.973979] cloud-init[242]: During handling of the above exception, another exception occurred:
[71972.974021] cloud-init[242]: Traceback (most recent call last):
[71972.974058] cloud-init[242]:   File "/usr/lib/python3/dist-packages/cloudinit/gpg.py", line 86, in getkeybyid
[71972.974094] cloud-init[242]:     recv_key(keyid, keyserver=keyserver)
[71972.974130] cloud-init[242]:   File "/usr/lib/python3/dist-packages/cloudinit/gpg.py", line 69, in recv_key
[71972.974185] cloud-init[242]:     "after %d tries: %s") % (key, keyserver, trynum, error))
[71972.974260] cloud-init[242]: ValueError: Failed to import key '9DC858229FC7DD38854AE2D88D81803C0EBFCD88' from keyserver 'keyserver.ubuntu.com' after 3 tries: Unexpected error while running command.
[71972.974320] cloud-init[242]: Command: ['gpg', '--keyserver=keyserver.ubuntu.com', '--recv-keys', '9DC858229FC7DD38854AE2D88D81803C0EBFCD88']
[71972.974388] cloud-init[242]: Exit code: -
[71972.974445] cloud-init[242]: Reason: [Errno 2] No such file or directory: b'gpg': b'gpg'
```
