### PR TITLE
images/opensuse: improve cloud-init support

### DIFF
--- a/images/opensuse.yaml
+++ b/images/opensuse.yaml
@@ -158,6 +158,14 @@ files:
   release:
   - 15.2
 
+- path: /etc/fstab
+  generator: dump
+  content: "# empty fstab to silence cloud-init warnings"
+  types:
+  - container
+  variants:
+  - cloud
+
 packages:
   manager: zypper
   update: true
@@ -198,6 +206,7 @@ packages:
 
   - packages:
     - cloud-init
+    - cloud-init-config-suse
     action: install
     variants:
     - cloud
@@ -266,7 +275,7 @@ actions:
     set -eux
 
     # Enable the cloud-init systemd service
-    systemctl enable cloud-init.service
+    systemctl enable cloud-init.service cloud-config.service cloud-final.service
   variants:
   - cloud
 


### PR DESCRIPTION
This fixes a few issues with the existing opensuse lxd images.

* Install `cloud-init-config-suse` explicitly. Currently `cloud-init-config-MicroOS` is being installed as a dependency to provide `/etc/cloud/cloud.cfg`, but this configuration disables some desirable modules including packages. The suse package seems to be a better choice for these images.
* Enable cloud-init config and final stages. These are disabled by default as well, and without them cloud-init loses a number of modules as configured.
* Write an empty fstab for cloud containers in order to silence the mounts module from warning.