### PR TITLE
bin/test-lxd-ovn-acl: Adds OVN port group clean up tests

### DIFF
--- a/bin/test-lxd-ovn-acl
+++ b/bin/test-lxd-ovn-acl
@@ -141,6 +141,7 @@ ovn-nbctl list port_group | grep -c lxd | grep 0 # Expect the unused OVN port gr
 
 # Create container with network assigned ACL and NIC specific ACL too. Check both sets of rules are applied.
 lxc network set ovn0 ipv6.dhcp.stateful=true security.acls=lxdbr0-ping
+ovn-nbctl list port_group | grep -c lxd | grep 1 # Expect 1 LXD related port group to exist now its assigned.
 lxc init images:ubuntu/20.04 c1
 lxc config device override c1 eth0 ipv4.address=10.10.11.2 ipv6.address=fd42:4242:4242:1011::2
 lxc start c1
@@ -157,7 +158,11 @@ lxc list
 lxc network acl create ingress-ping
 lxc network acl rule add ingress-ping ingress action=allow protocol=icmp4
 lxc network acl rule add ingress-ping ingress action=allow protocol=icmp6
+ovn-nbctl list port_group | grep -c lxd | grep 1 # Expect 1 LXD related port group to exist now new one not assigned.
+
 lxc config device set c1 eth0 security.acls=ingress-ping
+ovn-nbctl list port_group | grep -c lxd | grep 2 # Expect 2 LXD related port groups to exist now new one is assigned.
+
 lxc exec c2 -- ping -c1 -4 10.10.11.2
 lxc exec c2 -- ping -c1 -6 fd42:4242:4242:1011::2
 
@@ -189,8 +194,11 @@ lxc exec c1 -- ping -c1 -6 c2.lxd
 lxc network acl create test-empty-group
 lxc network acl rule remove ingress-ping ingress action=allow protocol=icmp4 source=ingress-ping
 lxc network acl rule remove ingress-ping ingress action=allow protocol=icmp6 source=ingress-ping
+ovn-nbctl list port_group | grep -c lxd | grep 2 # Expect 2 LXD related port groups to exist as new one not assigned.
+
 lxc network acl rule add ingress-ping ingress action=allow protocol=icmp4 source=test-empty-group
 lxc network acl rule add ingress-ping ingress action=allow protocol=icmp6 source=test-empty-group
+ovn-nbctl list port_group | grep -c lxd | grep 3 # Expect 3 LXD related port groups to exist as new one now used by ACL that is assigned.
 
 ! lxc exec c2 -- ping -c1 -4 c1.lxd || false
 ! lxc exec c2 -- ping -c1 -6 c1.lxd || false
@@ -200,8 +208,13 @@ lxc network acl rule add ingress-ping ingress action=allow protocol=icmp6 source
 # Cleanup.
 lxc delete -f c1
 lxc delete -f c2
+ovn-nbctl list port_group | grep -c lxd | grep 1 # Expect ingress-ping and test-empty-group to have been removed.
+
 lxc profile device remove default eth0 --project default
 lxc network delete ovn0 --project default
+ovn-nbctl list port_group | wc -l | grep 0 # Expect all OVN port groups to be cleaned up.
+ovn-nbctl list acl | wc -l | grep 0 # Expect all OVN ACLs to be cleaned up.
+
 lxc network delete lxdbr0 --project default
 lxc network acl delete lxdbr0-ping --project default
 lxc network acl delete ingress-ping --project default
@@ -209,8 +222,5 @@ lxc network acl delete test-empty-group --project default
 lxc profile device remove default root --project default
 lxc storage delete default --project default
 lxc project switch default
-
-ovn-nbctl list port_group | wc -l | grep 0 # Expect all OVN port groups to be cleaned up.
-ovn-nbctl list acl | wc -l | grep 0 # Expect all OVN ACLs to be cleaned up.
 
 FAIL=0


### PR DESCRIPTION
Requires: https://github.com/lxc/lxd/pull/8488

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>