### PR TITLE
bin/test-lxd-vm: Ensure to start VM after growing >10GB to ensure filesystem is grown

### DIFF
--- a/bin/test-lxd-vm
+++ b/bin/test-lxd-vm
@@ -148,6 +148,10 @@ do
         lxc delete -f v2
 
         echo "==> Publishing larger VM"
+        lxc start v1 # Start to ensure cloud-init grows filesystem before publish.
+        sleep 90
+        lxc info v1
+        lxc stop -f v1
         lxc publish v1 --alias vmbig
         lxc delete -f v1
         lxc storage set "${poolName}" volume.size 9GB


### PR DESCRIPTION
Otherwise we don't fully test that publish of >10GB image can be successfully used.

This is to test the fix from https://github.com/lxc/lxd/pull/8498

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>