### PR TITLE
bin/test-lxd-ovn: Make resilient to OVN setup races

### DIFF
--- a/bin/test-lxd-ovn
+++ b/bin/test-lxd-ovn
@@ -54,6 +54,7 @@ lxc network create lxdbr0 \
 
 # Create OVN network without specifying uplink parent network (check default selection works).
 lxc network create ovn-virtual-network --type=ovn
+sleep 2
 lxc network list | grep ovn-virtual-network
 
 echo "==> Launching a test container on lxdbr0"
@@ -348,9 +349,10 @@ lxc project switch testovn
 lxc profile device add default root disk path=/ pool=default
 
 # Create network inside project with same name and subnet as network in default project.
- lxc network create ovn-virtual-network network=lxdbr0 --type=ovn \
+lxc network create ovn-virtual-network network=lxdbr0 --type=ovn \
     ipv4.address="$(lxc network get ovn-virtual-network ipv4.address --project default)" ipv4.nat=true \
     ipv6.address="$(lxc network get ovn-virtual-network ipv6.address --project default)" ipv6.nat=true
+sleep 2
 
 # Test we cannot exceed specified project limits for networks.
 ! lxc network create ovn-virtual-network-toomany network=lxdbr0 --type=ovn || false
@@ -375,8 +377,8 @@ U3_IPV4="$(lxc list u3 -c4 --format=csv | cut -d' ' -f1)"
 U3_IPV6="$(lxc list u3 -c6 --format=csv | cut -d' ' -f1)"
 
 echo "==> lxdbr0 to OVN gateway in project testovn"
-lxc exec u1 --project default -- ping -c1 -4 10.10.10.201
-lxc exec u1 --project default -- ping -c1 -6 fd42:4242:4242:1010::201
+lxc exec u1 --project default -- ping -c1 -w5 -4 10.10.10.201
+lxc exec u1 --project default -- ping -c1 -w5 -6 fd42:4242:4242:1010::201
 
 echo "==> OVN to OVN in project testovn"
 lxc exec u2 -- ping -c1 -4 "${U3_IPV4}"
@@ -433,6 +435,7 @@ lxc network create dummy --type=physical \
     ipv6.gateway=2001:db8:1:1::1/64 \
     ipv4.ovn.ranges=192.0.2.10-192.0.2.19
 lxc network create ovn-virtual-network --type=ovn network=dummy
+sleep 2
 bridge link show | grep dummybr0 | wc -l | grep 1 # Check we have one port connected to the uplink bridge.
 ovs-vsctl list-br | grep ovn | wc  -l | grep 1 # Check we have one OVS bridge.
 ovnIPv4="$(lxc network get ovn-virtual-network volatile.network.ipv4.address)"
@@ -456,6 +459,7 @@ lxc network create dummy --type=physical \
     ipv6.gateway=2001:db8:1:1::1/64 \
     ipv4.ovn.ranges=192.0.2.10-192.0.2.19
 lxc network create ovn-virtual-network --type=ovn network=dummy
+sleep 2
 ovs-vsctl list-ports dummybr0 | grep patch-lxd-net | wc -l | grep 1 # Check bridge has an OVN patch port connected.
 ovnIPv4="$(lxc network get ovn-virtual-network volatile.network.ipv4.address)"
 ovnIPv6="$(lxc network get ovn-virtual-network volatile.network.ipv6.address)"


### PR DESCRIPTION
Having tested the OVN CI scripts in a local LXD Focal VM using the edge snap and the Focal supplied OVN packages, I've not been able to reproduce the Jenkins CI errors:

```
==> lxdbr0 to OVN gateway in project testovn
+ U3_IPV6=fd42:dc38:3278:d5c6:216:3eff:fe4d:e45d
+ echo ==> lxdbr0 to OVN gateway in project testovn
+ lxc exec u1 --project default -- ping -c1 -4 10.10.10.201
PING 10.10.10.201 (10.10.10.201) 56(84) bytes of data.
64 bytes from 10.10.10.201: icmp_seq=1 ttl=254 time=2.12 ms

--- 10.10.10.201 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 2.121/2.121/2.121/0.000 ms
+ lxc exec u1 --project default -- ping -c1 -6 fd42:4242:4242:1010::201
PING fd42:4242:4242:1010::201(fd42:4242:4242:1010::201) 56 data bytes

--- fd42:4242:4242:1010::201 ping statistics ---
1 packets transmitted, 0 received, 100% packet loss, time 0ms


Test failed
```

So this PR adds some additional logging.

The only PR merged between Saturday's successful run and Sunday's failure was https://github.com/lxc/lxd/pull/8563, which seems unlikely to have caused the failure, and indeed using the edge snap (that includes the PR) locally hasn't replicated the issue.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>