### PR TITLE
images/centos: Restrict network-device-down.service

### DIFF
--- a/images/centos.yaml
+++ b/images/centos.yaml
@@ -388,9 +388,30 @@ files:
   types:
   - container
   releases:
-  - 7
   - 8
   - 8-Stream
+
+- name: network-device-down.service
+  path: /etc/systemd/system/network-device-down.service
+  generator: dump
+  content: |-
+    [Unit]
+    Description=Turn off network device
+    Before=NetworkManager.service
+
+    [Service]
+    ExecStart=-/usr/sbin/ip link set eth0 down
+    Type=oneshot
+    RemainAfterExit=true
+
+    [Install]
+    WantedBy=default.target
+  types:
+  - container
+  releases:
+  - 7
+  variants:
+  - cloud
 
 - name: lxd-agent-workaround.service
   path: /etc/systemd/system/lxd-agent-workaround.service
@@ -683,6 +704,18 @@ actions:
   types:
   - container
   releases:
-  - 7
   - 8
   - 8-Stream
+
+- trigger: post-files
+  action: |-
+    #!/bin/sh
+    set -eux
+
+    systemctl enable network-device-down.service
+  types:
+  - container
+  releases:
+  - 7
+  variants:
+  - cloud


### PR DESCRIPTION
This fixes #265.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
