### PR TITLE
debian: let cloud-init manage vm interfaces

### DIFF
--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -862,22 +862,6 @@ files:
     auto lo
     iface lo inet loopback
 
-    source /etc/network/interfaces.d/*
-  types:
-  - container
-  variants:
-  - cloud
-
-- path: /etc/network/interfaces
-  generator: dump
-  content: |-
-    # This file describes the network interfaces available on your system
-    # and how to activate them. For more information, see interfaces(5).
-
-    # The loopback network interface
-    auto lo
-    iface lo inet loopback
-
     auto enp5s0
     iface enp5s0 inet dhcp
 
@@ -889,6 +873,23 @@ files:
   - buster
   - bullseye
   - sid
+
+- path: /etc/network/interfaces
+  generator: dump
+  content: |-
+    # This file describes the network interfaces available on your system
+    # and how to activate them. For more information, see interfaces(5).
+
+    # The loopback network interface
+    auto lo
+    iface lo inet loopback
+
+    source /etc/network/interfaces.d/*
+  types:
+  - container
+  - vm
+  variants:
+  - cloud
 
 - path: /etc/default/grub.d/50-lxd.cfg
   generator: dump


### PR DESCRIPTION
The cloud variant of the vm type currently populates the dhcp interface config. This is detrimental for assigning static IPs with cloud-init, and duplicative of cloud-init's default of dhcp on the first interface.

This PR makes the vm type behavior match the existing container type, and sets no interface config for cloud variants.