### PR TITLE
bin/test-lxd-storage-vm: Check config drive is exported readonly using virtiofs protocol

### DIFF
--- a/bin/test-lxd-storage-vm
+++ b/bin/test-lxd-storage-vm
@@ -62,6 +62,12 @@ do
         # Check 9p config drive share is exported readonly.
         lxc exec v1 -- mount -t 9p config /srv
         ! lxc exec v1 -- touch /srv/lxd-test || false
+        lxc exec v1 -- umount /srv
+
+        # Check virtiofs config drive share is exported readonly.
+        lxc exec v1 -- mount -t virtiofs config /srv
+        ! lxc exec v1 -- touch /srv/lxd-test || false
+        lxc exec v1 -- umount /srv
 
         echo "==> Checking VM root disk size is 10GB"
         lxc exec v1 -- df -B1000000000 | grep sda2 | grep 10


### PR DESCRIPTION
Depends on https://github.com/lxc/lxd/pull/8815
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>