### PR TITLE
bin/test-lxd-storage-vm: update config drive readonly tests to expect virtio-fs

### DIFF
--- a/bin/test-lxd-storage-vm
+++ b/bin/test-lxd-storage-vm
@@ -109,8 +109,8 @@ do
         # RW disks should use virtio-fs when used with the snap.
         lxc exec v1 -- mount | grep 'lxd_dir1rw on /srv/rw type virtiofs (rw,relatime)'
 
-        # RO disks should use 9p due to limitations of virtio-fs.
-        lxc exec v1 -- mount | grep 'lxd_dir1ro on /srv/ro type 9p (ro,relatime,sync,dirsync,access=client,trans=virtio)'
+        # RO disks should use virtio-fs when used with the snap but be mounted readonly.
+        lxc exec v1 -- mount | grep 'lxd_dir1ro on /srv/ro type virtiofs (ro,relatime)'
 
         # Check UID/GID are correct.
         lxc exec v1 -- stat -c '%u:%g' /srv/rw | grep '0:0'
@@ -118,7 +118,7 @@ do
 
         # Remount the readonly disk as rw inside VM and check that the disk is still readonly at the LXD layer.
         lxc exec v1 -- mount -oremount,rw /srv/ro
-        lxc exec v1 -- mount | grep 'lxd_dir1ro on /srv/ro type 9p (rw,relatime,sync,dirsync,access=client,trans=virtio)'
+        lxc exec v1 -- mount | grep 'lxd_dir1ro on /srv/ro type virtiofs (rw,relatime)'
         ! lxc exec v1 -- touch /srv/ro/lxd-test-ro || false
         ! lxc exec v1 -- mkdir /srv/ro/lxd-test-ro || false
         ! lxc exec v1 -- rm /srv/ro/lxd-test.txt || false


### PR DESCRIPTION
Relies on https://github.com/lxc/lxd/pull/8815

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>