### PR TITLE
images/centos: Only use network-scripts on CentOS 8 / 8-Stream

### DIFF
--- a/images/centos.yaml
+++ b/images/centos.yaml
@@ -497,6 +497,9 @@ packages:
     - container
     variants:
     - default
+    releases:
+    - 8
+    - 8-Stream
 
   - packages:
     - NetworkManager
@@ -679,3 +682,6 @@ actions:
   - container
   variants:
   - default
+  releases:
+  - 8
+  - 8-Stream


### PR DESCRIPTION
The network-scripts package is not available on CentOS 7.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
