### PR TITLE
images/centos: Install openssh-server on cloud images

### DIFF
--- a/images/centos.yaml
+++ b/images/centos.yaml
@@ -511,6 +511,7 @@ packages:
 
   - packages:
     - cloud-init
+    - openssh-server
     - NetworkManager
     action: install
     variants:


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
