### PR TITLE
images/fedora: Add empty /etc/fstab

### DIFF
--- a/images/fedora.yaml
+++ b/images/fedora.yaml
@@ -69,6 +69,11 @@ files:
 - path: /etc/machine-id
   generator: dump
 
+- path: /etc/fstab
+  generator: dump
+  types:
+  - container
+
 - path: /var/lib/dbus/machine-id
   generator: remove
 


### PR DESCRIPTION
This prevents cloud-init from failing.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
