### PR TITLE
images/rockylinux: Add openssh-server to cloud images

### DIFF
--- a/images/rockylinux.yaml
+++ b/images/rockylinux.yaml
@@ -234,6 +234,7 @@ packages:
   - packages:
     - cloud-init
     - NetworkManager
+    - openssh-server
     action: install
     variants:
     - cloud


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
