### PR TITLE
bin/test-lxd-images: Show systemd failures

### DIFF
--- a/bin/test-lxd-images
+++ b/bin/test-lxd-images
@@ -236,6 +236,8 @@ for url in $(lxc query "/1.0/instances" | jq -r .[]); do
     if lxc exec "${name}" -- sh -c "type systemctl" >/dev/null 2>&1; then
         if lxc exec "${name}" -- systemctl --failed 2>&1 | grep -q failed; then
             echo "FAIL: systemd clean: ${name}"
+            # Show the systemd failures
+            lxc exec "${name}" -- systemctl --failed
             FAIL=1
         else
             echo "PASS: systemd clean: ${name}"


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
