### PR TITLE
images/gentoo: Build cloud images for amd64 and i386 only

### DIFF
--- a/jenkins/jobs/image-gentoo.yaml
+++ b/jenkins/jobs/image-gentoo.yaml
@@ -48,6 +48,10 @@
             ${LXD_ARCHITECTURE} ${TYPE} 7200 ${WORKSPACE} \
             -o image.architecture=${ARCH} -o image.variant=${variant}
 
+    execution-strategy:
+      combination-filter: '
+      !(variant == "cloud" && architecture != "amd64" && architecture != "i386")'
+
     properties:
     - build-discarder:
         num-to-keep: 2


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
