### PR TITLE
jenkins/jobs: Add Gentoo for arm64

### DIFF
--- a/jenkins/jobs/image-gentoo.yaml
+++ b/jenkins/jobs/image-gentoo.yaml
@@ -12,6 +12,7 @@
         values:
         - amd64
         - armhf
+        - arm64
         - i386
         - ppc64el
         - s390x


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
