### PR TITLE
images: Remove busybox-gzip on openSUSE for ppc64

### DIFF
--- a/images/opensuse.yaml
+++ b/images/opensuse.yaml
@@ -173,6 +173,12 @@ packages:
   cleanup: true
   sets:
   - packages:
+    - busybox-gzip
+    action: remove
+    architectures:
+    - ppc64le
+
+  - packages:
     - apparmor-abstractions
     - apparmor-parser
     - dbus-1


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
