### PR TITLE
jenkins/jobs: Disable Gentoo/s390x systemd variant

### DIFF
--- a/jenkins/jobs/image-gentoo.yaml
+++ b/jenkins/jobs/image-gentoo.yaml
@@ -57,7 +57,8 @@
 
     execution-strategy:
       combination-filter: '
-      !(variant == "cloud" && architecture != "amd64" && architecture != "i386")'
+      !(variant == "cloud" && architecture != "amd64" && architecture != "i386")
+      && !(variant == "systemd" && architecture == "s390x")'
 
     properties:
     - build-discarder:


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
