### PR TITLE
jenkins/jobs: Remove openwrt 18.06 (EOL)

### DIFF
--- a/jenkins/jobs/image-openwrt.yaml
+++ b/jenkins/jobs/image-openwrt.yaml
@@ -17,7 +17,6 @@
         type: user-defined
         values:
         - snapshot
-        - "18.06"
         - "19.07"
 
     - axis:


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
