### PR TITLE
set missing locales for centos derivatives

### DIFF
--- a/images/almalinux.yaml
+++ b/images/almalinux.yaml
@@ -339,6 +339,9 @@ actions:
     # Disable loginuid in PAM stack
     sed -i '/^session.*pam_loginuid.so/s/^session/# session/' /etc/pam.d/*
 
+    # Set locale
+    localectl set-locale en_US.utf8
+
 - trigger: post-files
   action: |-
     #!/bin/sh

--- a/images/centos.yaml
+++ b/images/centos.yaml
@@ -644,6 +644,9 @@ actions:
     # Disable loginuid in PAM stack
     sed -i '/^session.*pam_loginuid.so/s/^session/# session/' /etc/pam.d/*
 
+    # Set locale
+    localectl set-locale en_US.utf8
+
 - trigger: post-files
   action: |-
     #!/bin/sh

--- a/images/rockylinux.yaml
+++ b/images/rockylinux.yaml
@@ -295,6 +295,8 @@ actions:
     echo 0 > /selinux/enforce
     # Disable loginuid in PAM stack
     sed -i '/^session.*pam_loginuid.so/s/^session/# session/' /etc/pam.d/*
+    # Set locale
+    localectl set-locale en_US.utf8
 
 - trigger: post-files
   action: |-


### PR DESCRIPTION
centos and derivatives don't have a default locale set (but for example the debian image has `en_US.utf8` set by default).