### PR TITLE
images/opensuse: Add growpart and e2fsprogs to desktop-kde variant

### DIFF
--- a/images/opensuse.yaml
+++ b/images/opensuse.yaml
@@ -308,6 +308,8 @@ packages:
   - packages:
     - discover
     - dolphin
+    - e2fsprogs
+    - growpart
     - konsole
     - sddm
     action: install


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
