### PR TITLE
images/opensuse: Prevent automatic screen locking

### DIFF
--- a/images/opensuse.yaml
+++ b/images/opensuse.yaml
@@ -216,6 +216,17 @@ files:
   variants:
   - desktop-kde
 
+- path: /home/opensuse/.config/kscreenlockerrc
+  generator: dump
+  content: |-
+    [Daemon]
+    Autolock=false
+    LockOnResume=false
+  types:
+  - vm
+  variants:
+  - desktop-kde
+
 packages:
   manager: zypper
   update: true


### PR DESCRIPTION
Since the `opensuse` user doesn't have a password, automatic screen
locking should be disabled. Otherwise, it'll ask for a password.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
