### PR TITLE
lxd-test-cluster: Update previous LXD to 4.18

### DIFF
--- a/jenkins/jobs/lxd-test-cluster.yaml
+++ b/jenkins/jobs/lxd-test-cluster.yaml
@@ -32,7 +32,7 @@
     - shell: |-
         cd /lxc-ci
         #PREVIOUS=$(curl -s -H "Snap-Device-Series: 16" https://api.snapcraft.io/v2/snaps/info/lxd | jq -r '.["channel-map"] | sort_by(.["created-at"]) | .[].channel.track' | grep -v latest | uniq | tail -2 | head -1)
-        PREVIOUS="4.16"
+        PREVIOUS="4.18"
         source=$(echo ${source} | sed -e "s/previous/${PREVIOUS}/g" -e "s/-/\//g")
         target=$(echo ${target} | sed -e "s/previous/${PREVIOUS}/g" -e "s/-/\//g")
         exec sudo /lxc-ci/bin/test-lxd-cluster 8 "${source}" "${target}"


### PR DESCRIPTION
Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>