### PR TITLE
images/opensuse: Drop busybox-gzip removal

### DIFF
--- a/images/opensuse.yaml
+++ b/images/opensuse.yaml
@@ -233,14 +233,6 @@ packages:
   cleanup: true
   sets:
   - packages:
-    - busybox-gzip
-    action: remove
-    architectures:
-    - ppc64le
-    releases:
-    - tumbleweed
-
-  - packages:
     - apparmor-abstractions
     - apparmor-parser
     - dbus-1


### PR DESCRIPTION
This package doesn't seem to exist anymore so it needs to be dropped.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
