### PR TITLE
ubuntu.yaml: define sources.list for riscv64

### DIFF
--- a/images/ubuntu.yaml
+++ b/images/ubuntu.yaml
@@ -578,6 +578,7 @@ packages:
     - powerpc
     - powerpc64
     - ppc64el
+    - riscv64
 
 actions:
 - trigger: post-update


### PR DESCRIPTION
The riscv64 architecture uses Ubuntu's ports repository.

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>