### PR TITLE
test-lxd-network-bridge-firewall: Fix tests now unmanaged NICs cannot specify IPs when filtering not enabled

### DIFF
--- a/bin/test-lxd-network-bridge-firewall
+++ b/bin/test-lxd-network-bridge-firewall
@@ -58,10 +58,13 @@ firewallTests() {
     lxc launch images:ubuntu/focal c1
     sleep 10
 
+    managed=0
+
     if echo $(lxc config show c1 --expanded) | grep "network: lxdbr0" -q; then
         echo "=> Performing basic DHCP/SLAAC ping tests"
         lxc exec c1 -- ping -c1 192.0.2.1
         lxc exec c1 -- ping -c1 2001:db8::1
+        managed=1
     fi
 
     # Disable DHCP client and SLAAC acceptance so we don't get automatic IPs added.
@@ -78,10 +81,20 @@ firewallTests() {
     lxc exec c1 -- ping -c1 2001:db8::1
 
     echo "=> Performing faked source IP ping tests with filtering"
-    lxc config device override c1 eth0 \
-        security.mac_filtering=true \
-        security.ipv4_filtering=true \
-        security.ipv6_filtering=true
+    if [ $managed -eq 1 ]; then
+        lxc config device override c1 eth0 \
+            security.mac_filtering=true \
+            security.ipv4_filtering=true \
+            security.ipv6_filtering=true
+    else
+        lxc config device override c1 eth0 \
+            security.mac_filtering=true \
+            security.ipv4_filtering=true \
+            security.ipv6_filtering=true \
+            ipv4.address=192.0.2.2 \
+            ipv6.address=2001:db8::2
+    fi
+
     lxc exec c1 -- ip a flush dev eth0
     lxc exec c1 -- ip a add 192.0.2.254/24 dev eth0
     lxc exec c1 -- ip a add 2001:db8::254/64 dev eth0 nodad
@@ -91,10 +104,21 @@ firewallTests() {
 
     echo "=> Performing faked source MAC ping tests without filtering"
     lxc stop -f c1
-    lxc config device set c1 eth0 \
-        security.mac_filtering=false \
-        security.ipv4_filtering=false \
-        security.ipv6_filtering=false
+
+    if [ $managed -eq 1 ]; then
+        lxc config device set c1 eth0 \
+            security.mac_filtering=false \
+            security.ipv4_filtering=false \
+            security.ipv6_filtering=false
+    else
+        lxc config device set c1 eth0 \
+            security.mac_filtering=false \
+            security.ipv4_filtering=false \
+            security.ipv6_filtering=false \
+            ipv4.address= \
+            ipv6.address=
+    fi
+
     lxc start c1
     sleep 10
     lxc exec c1 -- sysctl net.ipv6.conf.eth0.accept_ra=0
@@ -130,9 +154,7 @@ ip link set lxdbr0unmanaged up
 lxc profile device remove default eth0
 lxc profile device add default eth0 nic \
     nictype=bridged \
-    parent=lxdbr0unmanaged \
-    ipv4.address=192.0.2.2 \
-    ipv6.address=2001:db8::2
+    parent=lxdbr0unmanaged
 firewallTests
 lxc profile device remove default eth0
 ip a flush dev lxdbr0unmanaged
@@ -157,9 +179,7 @@ ip link set lxdbr0unmanaged up
 lxc profile device remove default eth0
 lxc profile device add default eth0 nic \
     nictype=bridged \
-    parent=lxdbr0unmanaged \
-    ipv4.address=192.0.2.2 \
-    ipv6.address=2001:db8::2
+    parent=lxdbr0unmanaged
 firewallTests
 lxc profile device remove default eth0
 ip link delete lxdbr0unmanaged


### PR DESCRIPTION
Introduced by https://github.com/lxc/lxd/pull/9406

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>