### PR TITLE
jenkins/jobs: Fix Gentoo variants

### DIFF
--- a/jenkins/jobs/image-gentoo.yaml
+++ b/jenkins/jobs/image-gentoo.yaml
@@ -26,7 +26,7 @@
         name: variant
         type: user-defined
         values:
-        - default
+        - openrc
         - cloud
         - systemd
 
@@ -46,8 +46,10 @@
         fi
 
         EXTRA_ARGS=""
-        if [ "${variant}" = "systemd" ]; then
-            EXTRA_ARGS="-o source.variant=systemd"
+        if [ "${variant}" = "cloud" ]; then
+            EXTRA_ARGS="-o source.variant=openrc"
+        else
+            EXTRA_ARGS="-o source.variant=${variant}"
         fi
 
         exec sudo /lxc-ci/bin/build-distro /lxc-ci/images/gentoo.yaml \


### PR DESCRIPTION
Gentoo no longer has a default variant. We therefore need to explicitly
use `openrc`.
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
