### PR TITLE
Install jq from apt

### DIFF
--- a/bin/build-cache
+++ b/bin/build-cache
@@ -53,7 +53,6 @@ apt-get clean
 
 # Setup snapd
 snap set system experimental.parallel-instances=true
-snap install core || true
 snap install go_113 --channel=1.13 --unaliased --classic
 snap install go_116 --channel=1.16 --unaliased --classic
 snap install go_117 --channel=1.17 --unaliased --classic

--- a/bin/test-lxd-cgroup
+++ b/bin/test-lxd-cgroup
@@ -29,9 +29,8 @@ done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
-snap install jq
+apt-get install jq iperf3 --yes
 lxd waitready --timeout=300
-apt-get install iperf3 --yes
 
 # Configure LXD
 lxd init --auto

--- a/bin/test-lxd-gpu-container
+++ b/bin/test-lxd-gpu-container
@@ -29,7 +29,7 @@ done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
-snap install jq
+apt-get install jq --yes
 lxd waitready --timeout=300
 
 # Check that NVIDIA is installed

--- a/bin/test-lxd-gpu-mig
+++ b/bin/test-lxd-gpu-mig
@@ -29,7 +29,7 @@ done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
-snap install jq
+apt-get install jq --yes
 lxd waitready --timeout=300
 
 # Configure LXD

--- a/bin/test-lxd-gpu-vm
+++ b/bin/test-lxd-gpu-vm
@@ -29,7 +29,7 @@ done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
-snap install jq
+apt-get install jq --yes
 lxd waitready --timeout=300
 
 # Configure LXD

--- a/bin/test-lxd-interception
+++ b/bin/test-lxd-interception
@@ -30,8 +30,7 @@ apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
 snap set lxd shiftfs.enable=true
-snap install jq
-apt-get install attr -y
+apt-get install jq attr --yes
 lxd waitready --timeout=300
 
 # Configure LXD

--- a/bin/test-lxd-maas
+++ b/bin/test-lxd-maas
@@ -29,7 +29,7 @@ done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
-snap install jq
+apt-get install jq --yes
 lxd waitready --timeout=300
 
 # Find network device

--- a/bin/test-lxd-network
+++ b/bin/test-lxd-network
@@ -32,7 +32,7 @@ done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
-snap install jq
+apt-get install jq --yes
 lxd waitready --timeout=300
 
 # Enable SR-IOV on nic and bring up

--- a/bin/test-lxd-network-bridge-firewall
+++ b/bin/test-lxd-network-bridge-firewall
@@ -29,7 +29,7 @@ done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
-snap install jq
+apt-get install jq --yes
 lxd waitready --timeout=300
 
 # Configure LXD

--- a/bin/test-lxd-network-ovn
+++ b/bin/test-lxd-network-ovn
@@ -29,7 +29,7 @@ done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
-snap install jq
+apt-get install jq --yes
 lxd waitready --timeout=300
 
 # Install OVN and dnsutils.

--- a/bin/test-lxd-network-ovn-acl
+++ b/bin/test-lxd-network-ovn-acl
@@ -29,7 +29,7 @@ done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
-snap install jq
+apt-get install jq --yes
 lxd waitready --timeout=300
 
 # Install OVN.

--- a/bin/test-lxd-network-routed
+++ b/bin/test-lxd-network-routed
@@ -29,7 +29,7 @@ done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
-snap install jq
+apt-get install jq --yes
 lxd waitready --timeout=300
 
 # Configure LXD.

--- a/bin/test-lxd-network-sriov
+++ b/bin/test-lxd-network-sriov
@@ -32,7 +32,7 @@ done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
-snap install jq
+apt-get install jq --yes
 lxd waitready --timeout=300
 
 # Enable SR-IOV on nic and bring up

--- a/bin/test-lxd-rbac
+++ b/bin/test-lxd-rbac
@@ -29,7 +29,7 @@ done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
-snap install jq bhttp
+apt-get install jq --yes bhttp
 lxd waitready --timeout=300
 
 # Configure LXD

--- a/bin/test-lxd-snapd-container
+++ b/bin/test-lxd-snapd-container
@@ -52,7 +52,6 @@ curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh
 
 # Install specific core snap channels if requested
 if [ "${CORE}" != "stable" ]; then
-    snap install core --channel=${CORE}
     snap install core18 --channel=${CORE}
     snap install snapd --channel=${CORE}
 fi

--- a/bin/test-lxd-storage-disks-vm
+++ b/bin/test-lxd-storage-disks-vm
@@ -35,7 +35,7 @@ done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
-snap install jq
+apt-get install jq --yes
 lxd waitready --timeout=300
 
 waitVMAgent() (

--- a/bin/test-lxd-storage-vm
+++ b/bin/test-lxd-storage-vm
@@ -33,7 +33,7 @@ done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
-snap install jq
+apt-get install jq --yes
 lxd waitready --timeout=300
 
 waitVMAgent() (

--- a/bin/test-lxd-storage-volumes-vm
+++ b/bin/test-lxd-storage-volumes-vm
@@ -33,7 +33,7 @@ done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
-snap install jq
+apt-get install jq --yes
 lxd waitready --timeout=300
 
 waitVMAgent() (

--- a/bin/test-lxd-usb
+++ b/bin/test-lxd-usb
@@ -29,7 +29,7 @@ done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
-snap install jq
+apt-get install jq --yes
 lxd waitready --timeout=300
 
 # Configure LXD


### PR DESCRIPTION
The stable `jq` snap brings version 1.5 while Focal has 1.6 as deb. `apt-get install` is also quicker than `snap install`. It also removes the need to bring the old `core` snap in.
