### PR TITLE
bin/test-lxd-*: use a subshell for waitSnapdSeed to isolate set +x

### DIFF
--- a/bin/test-lxd-cgroup
+++ b/bin/test-lxd-cgroup
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-waitSnapdSeed() {
+waitSnapdSeed() (
   set +x
   for i in $(seq 60); do # Wait up to 60s.
     if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
@@ -13,7 +13,7 @@ waitSnapdSeed() {
 
   echo "snapd not seeded after ${i}s"
   return 1 # Failed.
-}
+)
 
 cleanup() {
     echo ""

--- a/bin/test-lxd-gpu-container
+++ b/bin/test-lxd-gpu-container
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-waitSnapdSeed() {
+waitSnapdSeed() (
   set +x
   for i in $(seq 60); do # Wait up to 60s.
     if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
@@ -13,7 +13,7 @@ waitSnapdSeed() {
 
   echo "snapd not seeded after ${i}s"
   return 1 # Failed.
-}
+)
 
 cleanup() {
     echo ""

--- a/bin/test-lxd-gpu-mig
+++ b/bin/test-lxd-gpu-mig
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-waitSnapdSeed() {
+waitSnapdSeed() (
   set +x
   for i in $(seq 60); do # Wait up to 60s.
     if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
@@ -13,7 +13,7 @@ waitSnapdSeed() {
 
   echo "snapd not seeded after ${i}s"
   return 1 # Failed.
-}
+)
 
 cleanup() {
     echo ""

--- a/bin/test-lxd-gpu-vm
+++ b/bin/test-lxd-gpu-vm
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-waitSnapdSeed() {
+waitSnapdSeed() (
   set +x
   for i in $(seq 60); do # Wait up to 60s.
     if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
@@ -13,7 +13,7 @@ waitSnapdSeed() {
 
   echo "snapd not seeded after ${i}s"
   return 1 # Failed.
-}
+)
 
 cleanup() {
     echo ""

--- a/bin/test-lxd-images
+++ b/bin/test-lxd-images
@@ -4,7 +4,7 @@ set -eu
 TYPE="CONTAINER"
 [ "${1:-""}" = "vm" ] && TYPE="VIRTUAL-MACHINE"
 
-waitSnapdSeed() {
+waitSnapdSeed() (
   set +x
   for i in $(seq 60); do # Wait up to 60s.
     if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
@@ -16,7 +16,7 @@ waitSnapdSeed() {
 
   echo "snapd not seeded after ${i}s"
   return 1 # Failed.
-}
+)
 
 cleanup() {
     echo ""

--- a/bin/test-lxd-interception
+++ b/bin/test-lxd-interception
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-waitSnapdSeed() {
+waitSnapdSeed() (
   set +x
   for i in $(seq 60); do # Wait up to 60s.
     if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
@@ -13,7 +13,7 @@ waitSnapdSeed() {
 
   echo "snapd not seeded after ${i}s"
   return 1 # Failed.
-}
+)
 
 cleanup() {
     echo ""

--- a/bin/test-lxd-kernel
+++ b/bin/test-lxd-kernel
@@ -4,7 +4,7 @@ set -eu
 # Print kernel version
 echo "Starting test on: $(uname -a)"
 
-waitSnapdSeed() {
+waitSnapdSeed() (
   set +x
   for i in $(seq 60); do # Wait up to 60s.
     if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
@@ -16,7 +16,7 @@ waitSnapdSeed() {
 
   echo "snapd not seeded after ${i}s"
   return 1 # Failed.
-}
+)
 
 # Wait for snapd seeding
 waitSnapdSeed

--- a/bin/test-lxd-maas
+++ b/bin/test-lxd-maas
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-waitSnapdSeed() {
+waitSnapdSeed() (
   set +x
   for i in $(seq 60); do # Wait up to 60s.
     if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
@@ -13,7 +13,7 @@ waitSnapdSeed() {
 
   echo "snapd not seeded after ${i}s"
   return 1 # Failed.
-}
+)
 
 cleanup() {
     echo ""

--- a/bin/test-lxd-network
+++ b/bin/test-lxd-network
@@ -4,7 +4,7 @@ set -eu
 storageDevice="/dev/nvme0n1p3"
 parentNIC="enp10s0"
 
-waitSnapdSeed() {
+waitSnapdSeed() (
   set +x
   for i in $(seq 60); do # Wait up to 60s.
     if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
@@ -16,7 +16,7 @@ waitSnapdSeed() {
 
   echo "snapd not seeded after ${i}s"
   return 1 # Failed.
-}
+)
 
 cleanup() {
     echo ""

--- a/bin/test-lxd-network-bridge-firewall
+++ b/bin/test-lxd-network-bridge-firewall
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-waitSnapdSeed() {
+waitSnapdSeed() (
   set +x
   for i in $(seq 60); do # Wait up to 60s.
     if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
@@ -13,7 +13,7 @@ waitSnapdSeed() {
 
   echo "snapd not seeded after ${i}s"
   return 1 # Failed.
-}
+)
 
 cleanup() {
     echo ""

--- a/bin/test-lxd-network-ovn
+++ b/bin/test-lxd-network-ovn
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eux
 
-waitSnapdSeed() {
+waitSnapdSeed() (
   set +x
   for i in $(seq 60); do # Wait up to 60s.
     if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
@@ -13,7 +13,7 @@ waitSnapdSeed() {
 
   echo "snapd not seeded after ${i}s"
   return 1 # Failed.
-}
+)
 
 cleanup() {
     echo ""

--- a/bin/test-lxd-network-ovn-acl
+++ b/bin/test-lxd-network-ovn-acl
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eux
 
-waitSnapdSeed() {
+waitSnapdSeed() (
   set +x
   for i in $(seq 60); do # Wait up to 60s.
     if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
@@ -13,7 +13,7 @@ waitSnapdSeed() {
 
   echo "snapd not seeded after ${i}s"
   return 1 # Failed.
-}
+)
 
 cleanup() {
     echo ""

--- a/bin/test-lxd-network-routed
+++ b/bin/test-lxd-network-routed
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eux
 
-waitSnapdSeed() {
+waitSnapdSeed() (
   set +x
   for i in $(seq 60); do # Wait up to 60s.
     if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
@@ -13,7 +13,7 @@ waitSnapdSeed() {
 
   echo "snapd not seeded after ${i}s"
   return 1 # Failed.
-}
+)
 
 cleanup() {
     echo ""

--- a/bin/test-lxd-network-sriov
+++ b/bin/test-lxd-network-sriov
@@ -4,7 +4,7 @@ set -eu
 storageDevice="/dev/nvme0n1p3"
 parentNIC="enp10s0"
 
-waitSnapdSeed() {
+waitSnapdSeed() (
   set +x
   for i in $(seq 60); do # Wait up to 60s.
     if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
@@ -16,7 +16,7 @@ waitSnapdSeed() {
 
   echo "snapd not seeded after ${i}s"
   return 1 # Failed.
-}
+)
 
 cleanup() {
     echo ""

--- a/bin/test-lxd-rbac
+++ b/bin/test-lxd-rbac
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-waitSnapdSeed() {
+waitSnapdSeed() (
   set +x
   for i in $(seq 60); do # Wait up to 60s.
     if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
@@ -13,7 +13,7 @@ waitSnapdSeed() {
 
   echo "snapd not seeded after ${i}s"
   return 1 # Failed.
-}
+)
 
 cleanup() {
     echo ""

--- a/bin/test-lxd-storage-disks-vm
+++ b/bin/test-lxd-storage-disks-vm
@@ -64,7 +64,7 @@ waitVMAgent() (
     sleep 1
   done
 
-  echo VM "${vmName}" agent not running after "${i}"s
+  echo "VM ${vmName} agent not running after ${i}s"
   return 1 # Failed.
 )
 

--- a/bin/test-lxd-storage-disks-vm
+++ b/bin/test-lxd-storage-disks-vm
@@ -3,7 +3,7 @@ set -eux
 
 # This test uses openat2 which requires kernel >= 5.6 (so use Focal HWE).
 
-waitSnapdSeed() {
+waitSnapdSeed() (
   set +x
   for i in $(seq 60); do # Wait up to 60s.
     if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
@@ -15,7 +15,7 @@ waitSnapdSeed() {
 
   echo "snapd not seeded after ${i}s"
   return 1 # Failed.
-}
+)
 
 cleanup() {
     echo ""

--- a/bin/test-lxd-storage-disks-vm
+++ b/bin/test-lxd-storage-disks-vm
@@ -57,7 +57,7 @@ waitVMAgent() (
   local vmName=$1
   for i in $(seq 90) # Wait up to 90s.
   do
-    if [ "$(lxc info "${vmName}" | grep 127.0.0.1)" ] ; then
+    if lxc info "${vmName}" | grep -qF 127.0.0.1; then
       return 0 # Success.
     fi
 

--- a/bin/test-lxd-storage-vm
+++ b/bin/test-lxd-storage-vm
@@ -62,7 +62,7 @@ waitVMAgent() (
     sleep 1
   done
 
-  echo VM "${vmName}" agent not running after "${i}"s
+  echo "VM ${vmName} agent not running after ${i}s"
   return 1 # Failed.
 )
 

--- a/bin/test-lxd-storage-vm
+++ b/bin/test-lxd-storage-vm
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eux
 
-waitSnapdSeed() {
+waitSnapdSeed() (
   set +x
   for i in $(seq 60); do # Wait up to 60s.
     if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
@@ -13,7 +13,7 @@ waitSnapdSeed() {
 
   echo "snapd not seeded after ${i}s"
   return 1 # Failed.
-}
+)
 
 cleanup() {
     echo ""

--- a/bin/test-lxd-storage-vm
+++ b/bin/test-lxd-storage-vm
@@ -55,7 +55,7 @@ waitVMAgent() (
   local vmName=$1
   for i in $(seq 90) # Wait up to 90s.
   do
-    if [ "$(lxc info "${vmName}" | grep 127.0.0.1)" ] ; then
+    if lxc info "${vmName}" | grep -qF 127.0.0.1; then
       return 0 # Success.
     fi
 

--- a/bin/test-lxd-storage-volumes-vm
+++ b/bin/test-lxd-storage-volumes-vm
@@ -62,7 +62,7 @@ waitVMAgent() (
     sleep 1
   done
 
-  echo VM "${vmName}" agent not running after "${i}"s
+  echo "VM ${vmName} agent not running after ${i}s"
   return 1 # Failed.
 )
 

--- a/bin/test-lxd-storage-volumes-vm
+++ b/bin/test-lxd-storage-volumes-vm
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eux
 
-waitSnapdSeed() {
+waitSnapdSeed() (
   set +x
   for i in $(seq 60); do # Wait up to 60s.
     if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
@@ -13,7 +13,7 @@ waitSnapdSeed() {
 
   echo "snapd not seeded after ${i}s"
   return 1 # Failed.
-}
+)
 
 cleanup() {
     echo ""

--- a/bin/test-lxd-storage-volumes-vm
+++ b/bin/test-lxd-storage-volumes-vm
@@ -55,7 +55,7 @@ waitVMAgent() (
   local vmName=$1
   for i in $(seq 90) # Wait up to 90s.
   do
-    if [ "$(lxc info "${vmName}" | grep 127.0.0.1)" ] ; then
+    if lxc info "${vmName}" | grep -qF 127.0.0.1; then
       return 0 # Success.
     fi
 

--- a/bin/test-lxd-usb
+++ b/bin/test-lxd-usb
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-waitSnapdSeed() {
+waitSnapdSeed() (
   set +x
   for i in $(seq 60); do # Wait up to 60s.
     if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
@@ -13,7 +13,7 @@ waitSnapdSeed() {
 
   echo "snapd not seeded after ${i}s"
   return 1 # Failed.
-}
+)
 
 cleanup() {
     echo ""


### PR DESCRIPTION
Otherwise the undo the waitSnapdSeed `set -x` was affecting the global context.

Signed-off-by: Simon Deziel <simon.deziel@canonical.com>