### PR TITLE
Gentoo fixes

### DIFF
--- a/images/gentoo.yaml
+++ b/images/gentoo.yaml
@@ -433,6 +433,7 @@ packages:
   cleanup: true
   sets:
   - packages:
+    - net-misc/dhcpcd
     - sudo
     action: install
 

--- a/images/gentoo.yaml
+++ b/images/gentoo.yaml
@@ -573,7 +573,7 @@ actions:
   types:
   - vm
   variants:
-  - default
+  - openrc
   - cloud
 
 - trigger: post-files


### PR DESCRIPTION
- images: Install dhcpcd on Gentoo
- images: Replace default with openrc in Gentoo
