### PR TITLE
bin/test-lxd-storage-vm: Check root disk block device size rather than filesystem size

### DIFF
--- a/bin/test-lxd-storage-vm
+++ b/bin/test-lxd-storage-vm
@@ -72,6 +72,8 @@ lxc profile device add default eth0 nic network=lxdbr0
 
 poolName="vmpool$$"
 
+GiB=1073741823
+
 for poolDriver in $poolDriverList
 do
         echo "==> Create storage pool using driver ${poolDriver}"
@@ -101,7 +103,7 @@ do
         lxc exec v1 -- umount /srv
 
         echo "==> Checking VM root disk size is 10GiB"
-        lxc exec v1 -- df -B 1G --output=source,size | grep sda2 | grep -w 10
+        [ $(($(lxc exec v1 -- blockdev --getsize64 /dev/sda)/${GiB})) -eq "10" ]
 
         echo "==> Checking running VM snapshot"
         lxc snapshot v1
@@ -110,7 +112,7 @@ do
         waitVMAgent v2
 
         echo "==> Checking VM snapshot copy root disk size is 10GiB"
-        lxc exec v2 -- df -B 1G --output=source,size | grep sda2 | grep -w 10
+        [ $(($(lxc exec v2 -- blockdev --getsize64 /dev/sda)/${GiB})) -eq "10" ]
         lxc delete -f v2
         lxc delete v1/snap0
 
@@ -154,8 +156,7 @@ do
         waitVMAgent v1
 
         echo "==> Checking VM root disk size is 11GiB"
-        sleep 5 # Wait for resize to happen inside guest.
-        lxc exec v1 -- df -B 1G --output=source,size | grep sda2 | grep -w 11
+        [ $(($(lxc exec v1 -- blockdev --getsize64 /dev/sda)/${GiB})) -eq "11" ]
 
         echo "==> Check VM shrink is blocked"
         ! lxc config device set v1 root size=10GiB || false
@@ -241,8 +242,7 @@ do
         lxc info v1
 
         echo "==> Checking VM root disk size is 6GiB"
-        sleep 5 # Wait for resize to happen inside guest.
-        lxc exec v1 -- df -B 1G --output=source,size | grep sda2 | grep -w 6
+        [ $(($(lxc exec v1 -- blockdev --getsize64 /dev/sda)/${GiB})) -eq "6" ]
 
         echo "==> Deleting VM and reset pool volume.size"
         lxc delete -f v1
@@ -274,8 +274,7 @@ do
         lxc info v1
 
         echo "==> Checking VM root disk size is 7GiB"
-        sleep 5 # Wait for resize to happen inside guest.
-        lxc exec v1 -- df -B 1G --output=source,size | grep sda2 | grep -w 7
+        [ $(($(lxc exec v1 -- blockdev --getsize64 /dev/sda)/${GiB})) -eq "7" ]
         lxc stop -f v1
 
         echo "==> Copy to different storage pool and check size"
@@ -291,8 +290,7 @@ do
         lxc info v2
 
         echo "==> Checking copied VM root disk size is 7GiB"
-        lxc exec v2 -- df -B 1G --output=source,size | grep sda2 | grep -w 7
-        sleep 5 # Wait for resize to happen inside guest.
+        [ $(($(lxc exec v2 -- blockdev --getsize64 /dev/sda)/${GiB})) -eq "7" ]
         lxc delete -f v2
 
         echo "==> Grow above default volume size and copy to different storage pool"
@@ -303,8 +301,7 @@ do
         lxc info v2
 
         echo "==> Checking copied VM root disk size is 11GiB"
-        sleep 5 # Wait for resize to happen inside guest.
-        lxc exec v2 -- df -B 1G --output=source,size | grep sda2 | grep -w 11
+        [ $(($(lxc exec v2 -- blockdev --getsize64 /dev/sda)/${GiB})) -eq "11" ]
         lxc delete -f v2
 
         echo "==> Publishing larger VM"
@@ -327,8 +324,7 @@ do
         lxc info v1
 
         echo "==> Checking new VM root disk size is 11GiB"
-        sleep 5 # Wait for resize to happen inside guest.
-        lxc exec v1 -- df -B 1G --output=source,size | grep sda2 | grep -w 11
+        [ $(($(lxc exec v1 -- blockdev --getsize64 /dev/sda)/${GiB})) -eq "11" ]
 
         echo "===> Renaming VM"
         lxc stop -f v1


### PR DESCRIPTION
The PR https://github.com/lxc/lxc-ci/pull/421 was causing test failures locally for LVM (at least), due to the reliance on the mismatch between GiB and GB allowing (only sometimes) to account for use of the /boot partition space in the calculation of the / filesystem size.

Ultimately all these checks were supposed to be doing is to check (in a storage-driver agnostic way) that the disks are at the expected size.

By switching to looking at the block device size directly it means we don't have to wait for it to be resized by cloud-init, and we don't have to account for the /boot partition, because using `df` of the filesystem was just a proxy to the root disk's block device size, and not a reliable one at that.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>