### PR TITLE
images/alpine: allow cloud-init network-config

### DIFF
--- a/images/alpine.yaml
+++ b/images/alpine.yaml
@@ -280,14 +280,6 @@ files:
 
 - name: network-config
   generator: cloud-init
-  content: |-
-    version: 1
-    config:
-    - type: physical
-      name: eth0
-      subnets:
-      - type: dhcp
-        control: auto
   variants:
   - cloud
 


### PR DESCRIPTION
This config seems to prevent `cloud-init.network-config` and `user.network-config` from being used by Alpine containers. Untested on VMs.

Verified this change still allows the default DHCP on Alpine 3.13 and 3.15 cloud variants if no network-config is defined.

I did have to build the images using distrobuilder edge, so if this repo doesn't build using that I expect this PR would have to wait.

Note that cloud-init writes nameserver config to `/etc/network/interfaces`, which Alpine doesn't seem to support. I worked around that by writing `/etc/resolv.conf` directly in `cloud-init.user-config`:

```yaml
write_files:
  - content: |
      nameserver 10.0.0.1
      search zone.private
    path: /etc/resolv.conf

```
