### PR TITLE
Add centos 9 stream

### DIFF
--- a/images/centos.yaml
+++ b/images/centos.yaml
@@ -368,6 +368,7 @@ files:
   releases:
   - 8
   - 8-Stream
+  - 9-Stream
 
 - generator: fstab
   types:
@@ -410,6 +411,7 @@ files:
     ENV{ID_NET_DRIVER}=="veth", ENV{NM_UNMANAGED}="0"
   releases:
   - 8-Stream
+  - 9-Stream
 
 - name: network
   path: /etc/sysconfig/network
@@ -476,6 +478,7 @@ files:
   releases:
   - 8
   - 8-Stream
+  - 9-Stream
 
 - name: user-data
   generator: cloud-init
@@ -498,7 +501,6 @@ packages:
   sets:
   - packages:
     - cronie
-    - cronie-noanacron
     - curl
     - dhclient
     - glibc-langpack-en
@@ -512,6 +514,21 @@ packages:
     - rsyslog
     - vim-minimal
     action: install
+
+  - packages:
+    - cronie-noanacron
+    action: install
+    releases:
+    - 7
+    - 8
+    - 8-Stream
+
+  - packages:
+    - cronie-anacron
+    - NetworkManager
+    action: install
+    releases:
+    - 9-Stream
 
   - packages:
     - glibc-locale-source
@@ -585,6 +602,7 @@ packages:
     - 7
     - 8
     - 8-Stream
+    - 9-Stream
 
   - packages:
     - kernel-plus
@@ -602,6 +620,7 @@ packages:
     - vm
     releases:
     - 8-Stream
+    - 9-Stream
 
   - packages:
     - grub2-efi-x64
@@ -612,6 +631,7 @@ packages:
     - 7
     - 8
     - 8-Stream
+    - 9-Stream
     architectures:
     - x86_64
 
@@ -663,6 +683,7 @@ actions:
   - 7
   - 8
   - 8-Stream
+  - 9-Stream
 
 - trigger: post-packages
   action: |-
@@ -740,6 +761,25 @@ actions:
     #!/bin/sh
     set -eux
 
+    sed -ri 's#^options .+#options $kernelopts#g' /boot/loader/entries/*
+
+    target=/boot/efi/EFI/centos/grub.cfg
+    grub2-mkconfig -o "${target}"
+    sed -i "s#root=[^ ]*#root=/dev/sda2#g" "${target}"
+
+    # Regenerate initramfs
+    kver=$(ls /boot/initramfs-*.img | sed -r 's#.*initramfs-(.+)\.img#\1#')
+    dracut --kver "${kver}" -f
+  types:
+  - vm
+  releases:
+  - 9-Stream
+
+- trigger: post-files
+  action: |-
+    #!/bin/sh
+    set -eux
+
     systemctl enable NetworkManager.service
   types:
   - vm
@@ -780,3 +820,16 @@ actions:
   - 8-Stream
   architectures:
   - armhfp
+
+- trigger: post-files
+  action: |-
+    #!/bin/sh
+    set -eux
+
+    mkdir -p /etc/NetworkManager/conf.d/
+    printf "[main]\ndhcp=dhclient" > /etc/NetworkManager/conf.d/dhcp-client.conf
+
+    systemctl enable NetworkManager.service
+  releases:
+  - 9-Stream
+

--- a/jenkins/jobs/image-centos.yaml
+++ b/jenkins/jobs/image-centos.yaml
@@ -23,6 +23,7 @@
         - 7
         - 8
         - 8-Stream
+        - 9-Stream
 
     - axis:
         name: variant
@@ -47,8 +48,12 @@
             EXTRA_ARGS="-o source.url=http://mirror.math.princeton.edu/pub/centos-altarch/ -o source.skip_verification=true"
         fi
 
-        if [ "${architecture}" != "armhf" ] && ([ "${release}" = "8" ] || [ "${release}" = "8-Stream" ]); then
+        if [ "${architecture}" != "armhf" ] && ([ "${release}" = "8" ] || [ "${release}" = "8-Stream" ] || [ "${release}" = "9-Stream" ]); then
             EXTRA_ARGS="${EXTRA_ARGS} -o source.variant=boot"
+        fi
+
+        if [ "${release}" = "9-Stream" ]; then
+            EXTRA_ARGS="${EXTRA_ARGS} -o source.url=https://mirror1.hs-esslingen.de/pub/Mirrors/centos-stream"
         fi
 
         TYPE="container"
@@ -63,7 +68,8 @@
 
     execution-strategy:
       combination-filter: '
-      !(architecture=="armhf" && release == "8-Stream")
+      !(architecture=="armhf" && release == "9-Stream")
+      && !(architecture=="armhf" && release == "8-Stream")
       && !(architecture=="i386" && release != "7")'
 
     properties:


### PR DESCRIPTION
Hi there !

I made a PR to edit distrobuilder to be able to generate CentOS 9 stream images.

I have also edited this repository.

I'm sorry, I never worked on Jenkins. I am then unable to edit the CI. You will have to override the `url` parameter by one of the following (taken from [here](https://mirrors.centos.org/mirrorlist?path=/9-stream/BaseOS/x86_64/iso/)) :

```
# path = 9-stream/BaseOS/x86_64/iso country = FR country = PT country = DE country = CZ country = DK country = UA country = AT country = RU country = CH country = GB country = NL 
http://mirror.in2p3.fr/pub/linux/centos-stream/9-stream/BaseOS/x86_64/iso/
http://fr2.rpmfind.net/linux/centos-stream/9-stream/BaseOS/x86_64/iso/
http://centos-stream.ip-connect.info/9-stream/BaseOS/x86_64/iso/
http://mirrors.up.pt/centos-stream/9-stream/BaseOS/x86_64/iso/
http://linuxsoft.cern.ch/centos-stream/9-stream/BaseOS/x86_64/iso/
http://mirror.netsite.dk/centos-stream/9-stream/BaseOS/x86_64/iso/
http://mirror.karneval.cz/pub/linux/centos-stream/9-stream/BaseOS/x86_64/iso/
http://centos-stream.mirror.wearetriple.com/9-stream/BaseOS/x86_64/iso/
http://ftp.plusline.net/centos-stream/9-stream/BaseOS/x86_64/iso/
https://mirror1.hs-esslingen.de/pub/Mirrors/centos-stream/9-stream/BaseOS/x86_64/iso/
http://mirror.lanet.network/centos-stream/9-stream/BaseOS/x86_64/iso/
http://lon.mirror.rackspace.com/centos-stream/9-stream/BaseOS/x86_64/iso/
https://mirror.netzwerge.de/centos-stream/9-stream/BaseOS/x86_64/iso/
http://ftp.nsc.ru/pub/centos-9/9-stream/BaseOS/x86_64/iso/
http://mirror.im.jku.at/mirror/centos-stream/9-stream/BaseOS/x86_64/iso/
http://mirror.mijn.host/centos-stream/9-stream/BaseOS/x86_64/iso/
```

Signed-off-by: Sébastien BOUTON <s.bouton@titandc.fr>