### PR TITLE
images/alpine: Fix VM networking and enable sshd on VMs

### DIFF
--- a/images/alpine.yaml
+++ b/images/alpine.yaml
@@ -399,6 +399,19 @@ actions:
     #!/bin/sh
     set -eux
 
+    for svc_name in sshd; do
+        ln -fs /etc/init.d/${svc_name} /etc/runlevels/default/${svc_name}
+    done
+  types:
+  - vm
+  variants:
+  - cloud
+
+- trigger: post-files
+  action: |-
+    #!/bin/sh
+    set -eux
+
     setup-cloud-init
   variants:
   - cloud

--- a/images/alpine.yaml
+++ b/images/alpine.yaml
@@ -280,6 +280,14 @@ files:
 
 - name: network-config
   generator: cloud-init
+  content: |-
+    version: 1
+    config:
+    - type: physical
+      name: eth0
+      subnets:
+      - type: dhcp
+        control: auto
   variants:
   - cloud
 


### PR DESCRIPTION
1. Reverts my change from #439 as it breaks VM networking. Alpine does not use systemd-style interface names by default, and I was unable to get them working with the `eudev-netifnames` package. Therefore VMs need to configure `eth0`. Users will now be able to override this since lxc/distrobuilder#596. I tested both VMs and containers, both with and without `cloud-init.network-config` this time.

2. Enables sshd service on cloud VMs on boot. Containers start sshd using some other mechanism, so I would expect VMs to have it running as well. Only enabled on cloud variants since that's where [openssh is installed](https://github.com/lxc/lxc-ci/blob/13ff688ba1de1b5b270926b7fb8422769b40ae72/images/alpine.yaml#L323)