### PR TITLE
Drop openSUSE Leap 15.2 and CentOS 8

### DIFF
--- a/images/centos.yaml
+++ b/images/centos.yaml
@@ -279,7 +279,6 @@ files:
     MTU=
     DHCP_HOSTNAME=LXC_NAME
   releases:
-  - 8
   - 8-Stream
   types:
   - container
@@ -312,7 +311,6 @@ files:
     DHCP_HOSTNAME={{ container.name }}
     IPV6INIT=yes
   releases:
-  - 8
   - 8-Stream
   types:
   - container
@@ -329,7 +327,6 @@ files:
     MTU=
     DHCP_HOSTNAME={{ container.name }}
   releases:
-  - 8
   - 8-Stream
   types:
   - vm
@@ -366,7 +363,6 @@ files:
   types:
   - vm
   releases:
-  - 8
   - 8-Stream
   - 9-Stream
 
@@ -476,7 +472,6 @@ files:
   variants:
   - cloud
   releases:
-  - 8
   - 8-Stream
   - 9-Stream
 
@@ -520,7 +515,6 @@ packages:
     action: install
     releases:
     - 7
-    - 8
     - 8-Stream
 
   - packages:
@@ -547,7 +541,6 @@ packages:
     variants:
     - default
     releases:
-    - 8
     - 8-Stream
     architectures:
     - x86_64
@@ -563,7 +556,6 @@ packages:
     variants:
     - default
     releases:
-    - 8
     - 8-Stream
     architectures:
     - armhfp
@@ -600,7 +592,6 @@ packages:
     - vm
     releases:
     - 7
-    - 8
     - 8-Stream
     - 9-Stream
 
@@ -611,7 +602,6 @@ packages:
     - vm
     releases:
     - 7
-    - 8
 
   - packages:
     - kernel
@@ -629,7 +619,6 @@ packages:
     - vm
     releases:
     - 7
-    - 8
     - 8-Stream
     - 9-Stream
     architectures:
@@ -642,7 +631,6 @@ packages:
     - vm
     releases:
     - 7
-    - 8
     - 8-Stream
     architectures:
     - aaarch64
@@ -663,25 +651,12 @@ actions:
 - trigger: post-unpack
   action: |-
     #!/bin/sh
-    set -eux
-
-    # Enable the centosplus repo which has a kernel with 9p support
-    sed -i 's/^enabled=0/enabled=1/' /etc/yum.repos.d/CentOS-Linux-Plus.repo
-  types:
-  - vm
-  releases:
-  - 8
-
-- trigger: post-unpack
-  action: |-
-    #!/bin/sh
     # Generate machine-id in order for the kernel stuff to be configured properly
     systemd-machine-id-setup
   types:
   - vm
   releases:
   - 7
-  - 8
   - 8-Stream
   - 9-Stream
 
@@ -753,7 +728,6 @@ actions:
   types:
   - vm
   releases:
-  - 8
   - 8-Stream
 
 - trigger: post-files
@@ -797,7 +771,6 @@ actions:
   variants:
   - default
   releases:
-  - 8
   - 8-Stream
   architectures:
   - x86_64
@@ -816,7 +789,6 @@ actions:
   variants:
   - default
   releases:
-  - 8
   - 8-Stream
   architectures:
   - armhfp
@@ -832,4 +804,3 @@ actions:
     systemctl enable NetworkManager.service
   releases:
   - 9-Stream
-

--- a/images/opensuse.yaml
+++ b/images/opensuse.yaml
@@ -107,7 +107,6 @@ files:
   - container
   - vm
   releases:
-  - 15.2
   - 15.3
 
 - name: ifcfg-enp5s0
@@ -156,7 +155,6 @@ files:
   types:
   - vm
   release:
-  - 15.2
   - 15.3
 
 - path: /etc/fstab
@@ -255,7 +253,6 @@ packages:
     - hardlink
     action: install
     releases:
-    - 15.2
     - tumbleweed
 
   - packages:
@@ -369,18 +366,6 @@ actions:
     sed -i "s|'opensuse'|'opensuse-tumbleweed'|" $(find /usr -wholename '*/cloudinit/net/sysconfig.py')
   releases:
   - tumbleweed
-  variants:
-  - cloud
-
-- trigger: post-packages
-  action: |-
-    #!/bin/sh
-    set -eux
-
-    # Have the sysconfig network renderer support openSUSE Leap
-    sed -i "s|'opensuse'|'opensuse-leap'|" $(find /usr -wholename '*/cloudinit/net/sysconfig.py')
-  releases:
-  - 15.2
   variants:
   - cloud
 

--- a/jenkins/jobs/image-centos.yaml
+++ b/jenkins/jobs/image-centos.yaml
@@ -21,7 +21,6 @@
         type: user-defined
         values:
         - 7
-        - 8
         - 8-Stream
         - 9-Stream
 
@@ -44,11 +43,11 @@
         [ "${ARCH}" = "ppc64el" ] && ARCH="ppc64le"
 
         EXTRA_ARGS=""
-        if { [ "${release}" = "7" ] && [ "${architecture}" != "amd64" ]; } || { [ "${release}" = "8" ] && [ "${architecture}" = "armhf" ]; }; then
+        if { [ "${release}" = "7" ] && [ "${architecture}" != "amd64" ]; } || { [ "${architecture}" = "armhf" ]; }; then
             EXTRA_ARGS="-o source.url=http://mirror.math.princeton.edu/pub/centos-altarch/ -o source.skip_verification=true"
         fi
 
-        if [ "${architecture}" != "armhf" ] && ([ "${release}" = "8" ] || [ "${release}" = "8-Stream" ] || [ "${release}" = "9-Stream" ]); then
+        if [ "${architecture}" != "armhf" ] && ([ "${release}" = "8-Stream" ] || [ "${release}" = "9-Stream" ]); then
             EXTRA_ARGS="${EXTRA_ARGS} -o source.variant=boot"
         fi
 

--- a/jenkins/jobs/image-opensuse.yaml
+++ b/jenkins/jobs/image-opensuse.yaml
@@ -20,7 +20,6 @@
         name: release
         type: user-defined
         values:
-        - "15.2"
         - "15.3"
         - "tumbleweed"
 
@@ -55,8 +54,7 @@
 
     execution-strategy:
       combination-filter: '
-      !(architecture=="s390x" && release == "15.2")
-      && !(architecture=="i386" && release!="tumbleweed")
+      !(architecture=="i386" && release!="tumbleweed")
       && !(architecture != "amd64" && variant == "desktop-kde")'
 
     properties:


### PR DESCRIPTION
- jenkins/jobs: Drop openSUSE Leap 15.2 (EOL)
- images/opensuse: Drop openSUSE Leap 15.2 (EOL)
- jenkins/jobs: Drop CentOS 8 (EOL)
- images/centos: Drop CentOS 8 (EOL)
