### PR TITLE
images/fedora: Do not install deprecated components

### DIFF
--- a/images/fedora.yaml
+++ b/images/fedora.yaml
@@ -152,14 +152,12 @@ packages:
   sets:
   - packages:
     - cpio
-    - dhcp-client
     - file
     - findutils
     - fipscheck
     - gettext
     - glibc-all-langpacks
     - hardlink
-    - initscripts
     - ipcalc
     - iproute
     - iproute-tc
@@ -179,7 +177,6 @@ packages:
 
   - packages:
     - cloud-init
-    - network-scripts
     - NetworkManager
     - openssh-server
     action: install


### PR DESCRIPTION
Fedora uses systemd to boot and NetworkManager (or systemd-networkd in
container base) to set up networking -- these replace "initscripts" and
"network-scripts".

The "dhcp-client" package is not used at all -- both systemd-networkd
and NetworkManager use different tooling to do DHCP.

All of these have been quite been quite intentionally removed from images
provided by Fedora. Don't bring them back.

Signed-off-by: Lubomir Rintel <lkundrak@v3.sk>