### PR TITLE
images/fedora: Re-add initscripts package for cloud images

### DIFF
--- a/images/fedora.yaml
+++ b/images/fedora.yaml
@@ -178,6 +178,7 @@ packages:
 
   - packages:
     - cloud-init
+    - initscripts
     - NetworkManager
     - openssh-server
     action: install


### PR DESCRIPTION
The initscripts package is needed as cloud-init calls the `service`
command which is provided by this package.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
