### PR TITLE
images/pld: Fix locale issue

### DIFF
--- a/images/pld.yaml
+++ b/images/pld.yaml
@@ -168,8 +168,8 @@ actions:
 
       # locale
       cat << EOF >> /etc/sysconfig/i18n
-      LANG="C.UTF-8"
-      SUPPORTED_LOCALES="C.UTF-8/UTF-8"
+      LANG="en_US.UTF-8"
+      SUPPORTED_LOCALES="en_US.UTF-8/UTF-8"
       EOF
 
       localedb-gen


### PR DESCRIPTION
The C.UTF-8 locale complains about LC_MONETARY not being correct.
Switching to en_US.UTF-8 solves the issue.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
