### PR TITLE
images/voidlinux: avoid HTTP redirects for aarch64

### DIFF
--- a/images/voidlinux.yaml
+++ b/images/voidlinux.yaml
@@ -152,7 +152,7 @@ actions:
     #!/bin/sh
     set -eux
 
-    echo repository=https://repo-us.voidlinux.org/current//aarch64 > /usr/share/xbps.d/00-repository-main.conf
+    echo repository=https://repo-us.voidlinux.org/current/aarch64/ > /usr/share/xbps.d/00-repository-main.conf
   variants:
   - default
   architectures:


### PR DESCRIPTION
The mirror wants a trailing slash and when it's missing, it adds it with a redirects to HTTP and back to HTTPS:

```
$ wget -SO /dev/null https://repo-us.voidlinux.org/current//aarch64 2>&1 | grep ^Location
Location: http://repo-us.voidlinux.org/current/aarch64/ [following]
Location: https://repo-us.voidlinux.org/current/aarch64/ [following]

$ wget -SO /dev/null https://repo-us.voidlinux.org/current/aarch64/ 2>&1 | grep ^Location
# no redirection
```

Only aarch64 is missing the trailing slash. Drop the (harmless) double "/" while at it.