### PR TITLE
images/archlinux: Drop package haveged

### DIFF
--- a/images/archlinux.yaml
+++ b/images/archlinux.yaml
@@ -611,7 +611,6 @@ packages:
 
   - packages:
     - dnssec-anchors
-    - haveged
     - ldns
     - libedit
     - net-tools


### PR DESCRIPTION
This package isn't installed nor does it exist in the repo.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
