### PR TITLE
ubuntu.yaml: acpid is needed on Xenial VMs only

### DIFF
--- a/images/ubuntu.yaml
+++ b/images/ubuntu.yaml
@@ -480,6 +480,8 @@ packages:
     architectures:
     - amd64
     - arm64
+    releases:
+    - xenial
     types:
     - vm
 


### PR DESCRIPTION
acpid is still shipped in Bionic's server seed [1] but is not needed (tested locally to confirm). The server team removed it later so it is not in Focal's server seed [2].

1: https://people.canonical.com/~ubuntu-archive/germinate-output/ubuntu.bionic/server.seed
2: https://people.canonical.com/~ubuntu-archive/germinate-output/ubuntu.focal/server.seed