### PR TITLE
ubuntu.yaml: disco and eoan are long EOL

### DIFF
--- a/images/ubuntu.yaml
+++ b/images/ubuntu.yaml
@@ -506,8 +506,6 @@ packages:
     architectures:
     - arm64
     releases:
-    - disco
-    - eoan
     - focal
     - impish
     - jammy
@@ -527,7 +525,6 @@ packages:
     action: install
     releases:
     - bionic
-    - eoan
     - focal
     - impish
     - jammy


### PR DESCRIPTION
Signed-off-by: Simon Deziel <simon.deziel@canonical.com>