### PR TITLE
ubuntu.yaml: don't pull kernel headers

### DIFF
--- a/images/ubuntu.yaml
+++ b/images/ubuntu.yaml
@@ -515,7 +515,7 @@ packages:
     - vm
 
   - packages:
-    - linux-virtual-hwe-16.04
+    - linux-image-virtual-hwe-16.04
     action: install
     releases:
     - xenial
@@ -523,7 +523,7 @@ packages:
     - vm
 
   - packages:
-    - linux-virtual
+    - linux-image-virtual
     action: install
     releases:
     - bionic


### PR DESCRIPTION
Kernel headers are not needed most of the time and not
having them saves ~100MB on a Jammy VM.

Signed-off-by: Simon Deziel <simon.deziel@canonical.com>