### PR TITLE
jenkins/jobs/gentoo: Remove arm64 special case

### DIFF
--- a/jenkins/jobs/image-gentoo.yaml
+++ b/jenkins/jobs/image-gentoo.yaml
@@ -46,16 +46,10 @@
         fi
 
         EXTRA_ARGS=""
-        if [ "${architecture}" = "arm64" ]; then
-            if [ "${variant}" = "systemd" ]; then
-                EXTRA_ARGS="-o source.variant=${variant}"
-            fi
+        if [ "${variant}" = "cloud" ]; then
+            EXTRA_ARGS="-o source.variant=openrc"
         else
-            if [ "${variant}" = "cloud" ]; then
-                EXTRA_ARGS="-o source.variant=openrc"
-            else
-                EXTRA_ARGS="-o source.variant=${variant}"
-            fi
+            EXTRA_ARGS="-o source.variant=${variant}"
         fi
 
         exec sudo /lxc-ci/bin/build-distro /lxc-ci/images/gentoo.yaml \


### PR DESCRIPTION
The arm64 release didn't require source.variant to be set in the case of
openrc. This has now changed.

This removes the special case around arm64.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
