### PR TITLE
bin/build-lxd: Don't run unit tests in cluster mode

### DIFF
--- a/bin/build-lxd
+++ b/bin/build-lxd
@@ -169,7 +169,7 @@ if [ "$(uname -m)" != "x86_64" ]; then
 fi
 
 # Run the unit tests
-if [ "${LXD_BACKEND}" = "dir" ]; then
+if [ "${LXD_BACKEND}" = "dir" ] && [ "${LXD_TESTSUITE}" != "cluster" ]; then
     echo "==> UNIT BEGIN: all tests"
     GO_DQLITE_MULTITHREAD=1 go test -tags libsqlite3 ./...
     echo "==> UNIT DONE: all tests"


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>