### PR TITLE
s/apt/apt-get/ to avoid warning

### DIFF
--- a/bin/apply-updates
+++ b/bin/apply-updates
@@ -5,9 +5,9 @@ if [ "${ID}" = "arch" ]; then
     pacman -Syu --noconfirm
     pacman -Sc --noconfirm
 elif [ "${ID}" = "ubuntu" ] || [ "${ID}" = "debian" ] || [ "${ID}" = "elementary" ]; then
-    apt update
-    apt dist-upgrade -y
-    apt autoremove --purge -y
+    apt-get update
+    apt-get dist-upgrade -y
+    apt-get autoremove --purge -y
 elif [ "${ID}" = "ubuntu-core" ]; then
     snap refresh
 elif [ "${ID}" = "fedora" ]; then

--- a/bin/test-lxd-cgroup
+++ b/bin/test-lxd-cgroup
@@ -38,7 +38,7 @@ curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh
 # Install LXD
 while :; do
     [ ! -e /usr/bin/lxd ] && break
-    apt remove --purge lxd lxd-client --yes && break
+    apt-get remove --purge lxd lxd-client --yes && break
 done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true

--- a/bin/test-lxd-docker
+++ b/bin/test-lxd-docker
@@ -22,8 +22,8 @@ done
 set -eux
 
 # Install distro docker
-apt update --yes --force-yes
-apt install docker.io wget --yes --force-yes
+apt-get update --yes --force-yes
+apt-get install docker.io wget --yes --force-yes
 
 # Stop the distro docker
 systemctl stop docker.service

--- a/bin/test-lxd-gpu-container
+++ b/bin/test-lxd-gpu-container
@@ -38,7 +38,7 @@ curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh
 # Install LXD
 while :; do
     [ ! -e /usr/bin/lxd ] && break
-    apt remove --purge lxd lxd-client --yes && break
+    apt-get remove --purge lxd lxd-client --yes && break
 done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true

--- a/bin/test-lxd-gpu-mig
+++ b/bin/test-lxd-gpu-mig
@@ -38,7 +38,7 @@ curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh
 # Install LXD
 while :; do
     [ ! -e /usr/bin/lxd ] && break
-    apt remove --purge lxd lxd-client --yes && break
+    apt-get remove --purge lxd lxd-client --yes && break
 done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true

--- a/bin/test-lxd-gpu-vm
+++ b/bin/test-lxd-gpu-vm
@@ -38,7 +38,7 @@ curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh
 # Install LXD
 while :; do
     [ ! -e /usr/bin/lxd ] && break
-    apt remove --purge lxd lxd-client --yes && break
+    apt-get remove --purge lxd lxd-client --yes && break
 done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true

--- a/bin/test-lxd-images
+++ b/bin/test-lxd-images
@@ -41,12 +41,12 @@ curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh
 # Install LXD
 while :; do
     [ ! -e /usr/bin/lxd ] && break
-    apt remove --purge lxd lxd-client --yes && break
+    apt-get remove --purge lxd lxd-client --yes && break
 done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
-apt install jq zfsutils-linux -y --no-install-recommends
+apt-get install jq zfsutils-linux -y --no-install-recommends
 export PATH="/snap/bin/:${PATH}"
 lxd waitready --timeout=300
 

--- a/bin/test-lxd-interception
+++ b/bin/test-lxd-interception
@@ -38,7 +38,7 @@ curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh
 # Install LXD
 while :; do
     [ ! -e /usr/bin/lxd ] && break
-    apt remove --purge lxd lxd-client --yes && break
+    apt-get remove --purge lxd lxd-client --yes && break
 done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true

--- a/bin/test-lxd-maas
+++ b/bin/test-lxd-maas
@@ -38,7 +38,7 @@ curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh
 # Install LXD
 while :; do
     [ ! -e /usr/bin/lxd ] && break
-    apt remove --purge lxd lxd-client --yes && break
+    apt-get remove --purge lxd lxd-client --yes && break
 done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true

--- a/bin/test-lxd-migration
+++ b/bin/test-lxd-migration
@@ -28,18 +28,18 @@ trap cleanup EXIT HUP INT TERM
 
 # Make sure we're up to date
 while :; do
-    apt update && break
+    apt-get update && break
     sleep 10
 done
 
 while :; do
-    apt dist-upgrade --yes && break
+    apt-get dist-upgrade --yes && break
     sleep 10
 done
 
 # Install the LXD deb
-apt install -t "${series}" lxd lxd-client jq --yes
-apt install zfsutils-linux thin-provisioning-tools --yes
+apt-get install -t "${series}" lxd lxd-client jq --yes
+apt-get install zfsutils-linux thin-provisioning-tools --yes
 
 # Configure the LXD deb
 if [ "${series}" = "xenial-updates" ]; then

--- a/bin/test-lxd-network
+++ b/bin/test-lxd-network
@@ -62,7 +62,7 @@ curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh
 # Install LXD
 while :; do
     [ ! -e /usr/bin/lxd ] && break
-    apt remove --purge lxd lxd-client --yes && break
+    apt-get remove --purge lxd lxd-client --yes && break
 done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true

--- a/bin/test-lxd-network-bridge-firewall
+++ b/bin/test-lxd-network-bridge-firewall
@@ -38,7 +38,7 @@ curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh
 # Install LXD
 while :; do
     [ ! -e /usr/bin/lxd ] && break
-    apt remove --purge lxd lxd-client --yes && break
+    apt-get remove --purge lxd lxd-client --yes && break
 done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
@@ -55,7 +55,7 @@ lxc network create lxdbr0 \
 lxc profile device add default root disk path=/ pool=default
 
 echo "=> Setting up firewall tooling and checking versions"
-apt install nftables iptables ebtables -y
+apt-get install nftables iptables ebtables -y
 update-alternatives --set iptables /usr/sbin/iptables-legacy
 update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 update-alternatives --set ebtables /usr/sbin/ebtables-legacy

--- a/bin/test-lxd-network-ovn
+++ b/bin/test-lxd-network-ovn
@@ -38,7 +38,7 @@ curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh
 # Install LXD
 while :; do
     [ ! -e /usr/bin/lxd ] && break
-    apt remove --purge lxd lxd-client --yes && break
+    apt-get remove --purge lxd lxd-client --yes && break
 done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
@@ -47,7 +47,7 @@ apt-get install jq --yes
 lxd waitready --timeout=300
 
 # Install OVN and dnsutils.
-apt install ovn-host ovn-central dnsutils --yes
+apt-get install ovn-host ovn-central dnsutils --yes
 
 # Configure OVN.
 ovs-vsctl set open_vswitch . \
@@ -677,7 +677,7 @@ ovn_forward_tests() {
 
     # Check DNS TCP forwarding using default target rule.
     lxc exec u1 -- systemctl mask dnsmasq
-    lxc exec u1 -- apt install dnsmasq -y
+    lxc exec u1 -- apt-get install dnsmasq -y
 cat <<EOF | lxc exec u1 -- tee /etc/dnsmasq.d/lxd_test.conf
 interface=eth0
 bind-interfaces
@@ -702,7 +702,7 @@ EOF
     U2_IPV6="$(lxc list u2 -c6 --format=csv | cut -d' ' -f1)"
 
     lxc exec u2 -- systemctl mask dnsmasq
-    lxc exec u2 -- apt install dnsmasq -y
+    lxc exec u2 -- apt-get install dnsmasq -y
 cat <<EOF | lxc exec u2 -- tee /etc/dnsmasq.d/lxd_test.conf
 interface=eth0
 bind-interfaces
@@ -902,7 +902,7 @@ ovn_peering_tests() {
 
     # Install tcpdump and check we can detect ICMP packets coming to the ovn2 instance from ovn1 instance when
     # pinging the allowed addresses.
-    lxc exec ovn2 --project=ovn2 -- apt install tcpdump -y
+    lxc exec ovn2 --project=ovn2 -- apt-get install tcpdump -y
     lxc exec ovn1 -T -n --project=ovn1 -- ping -c3 -4 -W5 "${ovn2NICIPv4}" || true &
     lxc exec ovn2 -T -n --project=ovn2 -- timeout 5s tcpdump -i eth0 -nn icmp and src ${ovn1NICIPv4} -q -c 1 > /dev/null
     wait

--- a/bin/test-lxd-network-ovn-acl
+++ b/bin/test-lxd-network-ovn-acl
@@ -38,7 +38,7 @@ curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh
 # Install LXD.
 while :; do
     [ ! -e /usr/bin/lxd ] && break
-    apt remove --purge lxd lxd-client --yes && break
+    apt-get remove --purge lxd lxd-client --yes && break
 done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
@@ -47,7 +47,7 @@ apt-get install jq --yes
 lxd waitready --timeout=300
 
 # Install OVN.
-apt install ovn-host ovn-central --yes
+apt-get install ovn-host ovn-central --yes
 
 # Configure OVN.
 ovs-vsctl set open_vswitch . \
@@ -146,7 +146,7 @@ ping -c1 -6 fd42:4242:4242:1010::2
 
 # Check default rule action is reject (disable acl, install dig in c1, then re-enable acl).
 lxc network unset ovn0 security.acls
-lxc exec c1 -- apt install dnsutils -y
+lxc exec c1 -- apt-get install dnsutils -y
 lxc network set ovn0 security.acls=lxdbr0-ping
 lxc exec c1 -- dig @10.10.11.3 +tcp +timeout=1 lxdbr0.test | grep "refused"
 lxc exec c1 -- dig @fd42:4242:4242:1010::2 +tcp +timeout=1 lxdbr0.test | grep "refused"
@@ -215,7 +215,7 @@ ovn-nbctl list acl | grep -c 'name.*eth0-ingress' | grep 0
 ovn-nbctl list acl | grep -c 'name.*eth0-egress' | grep 0
 
 # Test c1's default ingress rule defaults to reject by querying from c2 (which now has no ACLs applied).
-lxc exec c2 -- apt install dnsutils -y
+lxc exec c2 -- apt-get install dnsutils -y
 lxc exec c2 -- dig @c1.lxd -4 +tcp +timeout=1 -p 5053 lxdbr0.test | grep "refused"
 lxc exec c2 -- dig @c1.lxd -6 +tcp +timeout=1 -p 5053 lxdbr0.test | grep "refused"
 lxc exec c2 -- ping -c1 -4 c1.lxd | grep "Host Unreachable"

--- a/bin/test-lxd-network-routed
+++ b/bin/test-lxd-network-routed
@@ -38,7 +38,7 @@ curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh
 # Install LXD
 while :; do
     [ ! -e /usr/bin/lxd ] && break
-    apt remove --purge lxd lxd-client --yes && break
+    apt-get remove --purge lxd lxd-client --yes && break
 done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true

--- a/bin/test-lxd-network-sriov
+++ b/bin/test-lxd-network-sriov
@@ -122,7 +122,7 @@ curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh
 # Install LXD
 while :; do
     [ ! -e /usr/bin/lxd ] && break
-    apt remove --purge lxd lxd-client --yes && break
+    apt-get remove --purge lxd lxd-client --yes && break
 done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true

--- a/bin/test-lxd-performance
+++ b/bin/test-lxd-performance
@@ -43,17 +43,17 @@ trap cleanup EXIT HUP INT TERM
 
 # Make sure we're up to date
 while :; do
-    apt update && break
+    apt-get update && break
     sleep 10
 done
 
 while :; do
-    apt dist-upgrade --yes && break
+    apt-get dist-upgrade --yes && break
     sleep 10
 done
 
 # Setup the environment
-apt remove --purge lxd lxd-client lxcfs liblxc1 --yes
+apt-get remove --purge lxd lxd-client lxcfs liblxc1 --yes
 
 # Configure ceph
 if [ "${LXD_BACKEND}" = "ceph" ]; then

--- a/bin/test-lxd-pylxd
+++ b/bin/test-lxd-pylxd
@@ -20,17 +20,17 @@ trap cleanup EXIT HUP INT TERM
 
 # Make sure we're up to date
 while :; do
-    apt update && break
+    apt-get update && break
     sleep 10
 done
 
 while :; do
-    apt dist-upgrade --yes && break
+    apt-get dist-upgrade --yes && break
     sleep 10
 done
 
 # Remove pre-installed LXD
-apt remove --purge lxd lxd-client lxcfs --yes
+apt-get remove --purge lxd lxd-client lxcfs --yes
 
 # Install the LXD snap
 if [ "${track}" = "latest" ]; then

--- a/bin/test-lxd-rbac
+++ b/bin/test-lxd-rbac
@@ -38,7 +38,7 @@ curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh
 # Install LXD
 while :; do
     [ ! -e /usr/bin/lxd ] && break
-    apt remove --purge lxd lxd-client --yes && break
+    apt-get remove --purge lxd lxd-client --yes && break
 done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true

--- a/bin/test-lxd-storage-disks-vm
+++ b/bin/test-lxd-storage-disks-vm
@@ -44,7 +44,7 @@ curl -s http://canonical-lxd.stgraber.org/config/ceph.sh | sh
 # Install LXD
 while :; do
     [ ! -e /usr/bin/lxd ] && break
-    apt remove --purge lxd lxd-client --yes && break
+    apt-get remove --purge lxd lxd-client --yes && break
 done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true

--- a/bin/test-lxd-storage-vm
+++ b/bin/test-lxd-storage-vm
@@ -42,7 +42,7 @@ curl -s http://canonical-lxd.stgraber.org/config/ceph.sh | sh
 # Install LXD
 while :; do
     [ ! -e /usr/bin/lxd ] && break
-    apt remove --purge lxd lxd-client --yes && break
+    apt-get remove --purge lxd lxd-client --yes && break
 done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true

--- a/bin/test-lxd-storage-volumes-vm
+++ b/bin/test-lxd-storage-volumes-vm
@@ -42,7 +42,7 @@ curl -s http://canonical-lxd.stgraber.org/config/ceph.sh | sh
 # Install LXD
 while :; do
     [ ! -e /usr/bin/lxd ] && break
-    apt remove --purge lxd lxd-client --yes && break
+    apt-get remove --purge lxd lxd-client --yes && break
 done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true

--- a/bin/test-lxd-usb
+++ b/bin/test-lxd-usb
@@ -44,7 +44,7 @@ curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh
 # Install LXD
 while :; do
     [ ! -e /usr/bin/lxd ] && break
-    apt remove --purge lxd lxd-client --yes && break
+    apt-get remove --purge lxd lxd-client --yes && break
 done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true


### PR DESCRIPTION
Even on Jammy with apt version 2.4.3, apt CLI isn't
considered stable causing this warning to be emit:

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.