### PR TITLE
test-lxd-pylxd: remove LXD snap before installing from the desired channel

### DIFF
--- a/bin/test-lxd-pylxd
+++ b/bin/test-lxd-pylxd
@@ -44,6 +44,7 @@ fi
 # Configure to use the proxy
 curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh || true
 
+snap remove lxd || true
 snap install lxd --channel="${snapd_channel}"
 export PATH="/snap/bin/:${PATH}"
 lxd waitready --timeout=120


### PR DESCRIPTION
I noticed our MAAS VMs logged the following when running pylxd tests:

```
snap "lxd" is already installed, see 'snap help refresh'
```

So apparently the VM already had LXD installed so wasn't getting the desired version. This also explains why I couldn't reproduce the issue #10164 in manual tests using a fresh Jammy (`lxc launch images:ubuntu/jammy`) VM.