### PR TITLE
ubuntu: linux-image-virtual has what we need for desktop

### DIFF
--- a/images/ubuntu.yaml
+++ b/images/ubuntu.yaml
@@ -580,7 +580,6 @@ packages:
     - vm
 
   - packages:
-    - linux-image-generic
     - ubuntu-desktop-minimal
     action: install
     variants:


### PR DESCRIPTION
With https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1960633 fixed
we no longer need to pull the bigger linux-image-generic meta package
as what we need is brought in by linux-image-virtual that we already use
for non desktop flavors.

If we ever want to build Bionic desktop images, we'd need to bring
in linux-image-virtual-hwe-18.04 kernel as the GA -virtual kernel
doesn't have the required dependencies.