### PR TITLE
Fix DNS issue in debian/bullseye/cloud

### DIFF
--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -1212,9 +1212,32 @@ actions:
     # Enable systemd-resolved
     systemctl enable systemd-resolved.service
   releases:
-  - bullseye
   - bookworm
   - sid
+
+- trigger: post-packages
+  action: |-
+    #!/bin/sh
+    set -eux
+
+    # Enable systemd-resolved
+    systemctl enable systemd-resolved.service
+  variants:
+  - default
+  releases:
+  - bullseye
+
+- trigger: post-packages
+  action: |-
+    #!/bin/sh
+    set -eux
+
+    # Disable systemd-resolved
+    systemctl disable systemd-resolved.service
+  variants:
+  - cloud
+  releases:
+  - bullseye
 
 - trigger: post-packages
   action: |-


### PR DESCRIPTION
Hello,

I think the network issue in #503 is not completely fixed yet byt #504 .

With fix in #504, here is my resolv.conf file :

```
root@c1:~# cat /etc/resolv.conf
# Dynamic resolv.conf(5) file for glibc resolver(3) generated by resolvconf(8)
#     DO NOT EDIT THIS FILE BY HAND -- YOUR CHANGES WILL BE OVERWRITTEN
# 127.0.0.53 is the systemd-resolved stub resolver.
# run "resolvectl status" to see details about the actual nameservers.

nameserver 8.8.8.8
nameserver 8.8.4.4
nameserver 127.0.0.53
```

As you can see, 127.0.0.53 from `systemd-resolved.service` still shows up but is not operationnal so the DNS resolution is not reliable in the container. If I disable `systemd-resolved.service`, this issue disappears.

Shouldn't we also disable this service in the template ?

Thank you!
Jean-Michel

Signed-off-by: Jean-Michel DILLY <jmdilly@adista.fr>