### PR TITLE
debian/images: Remove systemd network file from 11/cloud

### DIFF
--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -938,7 +938,6 @@ files:
   variants:
   - cloud
   releases:
-  - bullseye
   - bookworm
 
 - path: /etc/default/grub.d/50-lxd.cfg


### PR DESCRIPTION
This removes the enp5s0.network file from the 11/cloud image. It does
not fix anything, it just clarifies that systemd-networkd isn't used.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
