### PR TITLE
images/gentoo: Disable systemd-binfmt.service

### DIFF
--- a/images/gentoo.yaml
+++ b/images/gentoo.yaml
@@ -605,6 +605,9 @@ actions:
 
     systemctl enable systemd-resolved
     systemctl enable systemd-networkd
+
+    # Disable systemd-binfmt as it doesn't work in containers
+    systemctl disable systemd-binfmt.service
   variants:
   - systemd
 


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
