### PR TITLE
images/gentoo: Disable timer instead of service file

### DIFF
--- a/images/gentoo.yaml
+++ b/images/gentoo.yaml
@@ -607,7 +607,7 @@ actions:
     systemctl enable systemd-networkd
 
     # Disable systemd-binfmt as it doesn't work in containers
-    systemctl disable systemd-binfmt.service
+    systemctl disable systemd-binfmt.timer
   variants:
   - systemd
 


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
