### PR TITLE
Image review

### DIFF
--- a/images/alpine.yaml
+++ b/images/alpine.yaml
@@ -315,7 +315,6 @@ packages:
     - sudo
     action: install
     releases:
-    - 3.12
     - 3.13
     - 3.14
 

--- a/jenkins/jobs/image-alpine.yaml
+++ b/jenkins/jobs/image-alpine.yaml
@@ -21,7 +21,6 @@
         name: release
         type: user-defined
         values:
-        - "3.12"
         - "3.13"
         - "3.14"
         - "3.15"
@@ -56,7 +55,6 @@
 
     execution-strategy:
       combination-filter: '
-      !(variant=="cloud" && release == "3.12") &&
       !(variant=="cloud" && architecture == "s390x")'
 
     properties:


### PR DESCRIPTION
- jenkins/jobs: Drop Alpine Linux 3.12 (EOL)
- images/alpine: Remove 3.12
