### PR TITLE
jenkins: Revert ovn tests to run on focal

### DIFF
--- a/jenkins/jobs/lxd-test-network-ovn-acl.yaml
+++ b/jenkins/jobs/lxd-test-network-ovn-acl.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/maas-run tags=virtual jammy ga-22.04 default bin/test-lxd-network-ovn-acl
+        exec sudo /lxc-ci/bin/maas-run tags=virtual focal ga-20.04 default bin/test-lxd-network-ovn-acl
 
     properties:
     - build-discarder:

--- a/jenkins/jobs/lxd-test-network-ovn.yaml
+++ b/jenkins/jobs/lxd-test-network-ovn.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/maas-run tags=virtual jammy ga-22.04 default bin/test-lxd-network-ovn
+        exec sudo /lxc-ci/bin/maas-run tags=virtual focal ga-20.04 default bin/test-lxd-network-ovn
 
     properties:
     - build-discarder:


### PR DESCRIPTION
OVN on jammy is busted, so revert until we can figure out what is broken in OVN and get a fix.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>