### PR TITLE
bin/test-lxd-storage-vm: Clean up storage pool

### DIFF
--- a/bin/test-lxd-storage-vm
+++ b/bin/test-lxd-storage-vm
@@ -405,6 +405,7 @@ do
         lxc profile delete vmsmall
 
         echo "==> Deleting storage pool"
+        lxc storage delete "${poolName}3"
         lxc storage delete "${poolName}2"
         lxc storage delete "${poolName}"
 done


### PR DESCRIPTION
This cleans up the storage pool which is used to test the same-driver
copy.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
