### PR TITLE
jenkins/jobs: Update Fedora architectures

### DIFF
--- a/jenkins/jobs/image-fedora.yaml
+++ b/jenkins/jobs/image-fedora.yaml
@@ -54,8 +54,7 @@
 
     execution-strategy:
       combination-filter: '
-      !(architecture == "armhf" && release != "36") &&
-      !(architecture == "ppc64el" && release != "34")'
+      !(architecture == "armhf" && release != "36")'
 
     properties:
     - build-discarder:

--- a/jenkins/jobs/image-fedora.yaml
+++ b/jenkins/jobs/image-fedora.yaml
@@ -54,6 +54,7 @@
 
     execution-strategy:
       combination-filter: '
+      !(architecture == "armhf" && release != "36") &&
       !(architecture == "ppc64el" && release != "34")'
 
     properties:


### PR DESCRIPTION
- jenkins/jobs/fedora: Remove armhf images on v34 and v35
- jenkins/jobs/fedora: Remove ppc64 restriction
