### PR TITLE
bin/test-lxd-storage-vm: Fixes test on lvm-thin backend

### DIFF
--- a/bin/test-lxd-storage-vm
+++ b/bin/test-lxd-storage-vm
@@ -76,10 +76,8 @@ GiB=1073741823
 for poolDriver in $poolDriverList
 do
         echo "==> Create storage pool using driver ${poolDriver}"
-        if [ "${poolDriver}" = "dir" ]; then
+        if [ "${poolDriver}" = "dir" ] || [ "${poolDriver}" = "ceph" ]; then
                 lxc storage create "${poolName}" "${poolDriver}"
-        elif [ "${poolDriver}" = "ceph" ]; then
-                lxc storage create "${poolName}" "${poolDriver}" source="${poolName}"
         elif [ "${poolDriver}" = "lvm" ]; then
                 lxc storage create "${poolName}" "${poolDriver}" size=40GiB lvm.use_thinpool=false
         elif [ "${poolDriver}" = "lvm-thin" ]; then
@@ -341,6 +339,27 @@ do
         [ $(($(lxc exec v1 -- blockdev --getsize64 /dev/sda)/${GiB})) -eq "7" ]
         lxc stop -f v1
 
+        echo "==> Copy to different storage pool with same driver and check size"
+        if [ "${poolDriver}" = "dir" ] || [ "${poolDriver}" = "ceph" ]; then
+                lxc storage create "${poolName}2" "${poolDriver}"
+        elif [ "${poolDriver}" = "lvm" ]; then
+                lxc storage create "${poolName}2" "${poolDriver}" size=40GiB lvm.use_thinpool=false
+        elif [ "${poolDriver}" = "lvm-thin" ]; then
+                lxc storage create "${poolName}2" lvm size=20GiB
+        else
+                lxc storage create "${poolName}2" "${poolDriver}" size=20GiB
+        fi
+
+        lxc copy v1 v2 -s "${poolName}2"
+        lxc start v2
+        waitVMAgent v2
+        lxc info v2
+
+        echo "==> Checking copied VM root disk size is 7GiB"
+        [ $(($(lxc exec v2 -- blockdev --getsize64 /dev/sda)/${GiB})) -eq "7" ]
+        lxc delete -f v2
+        lxc storage delete "${poolName}2"
+
         echo "==> Copy to different storage pool with different driver and check size"
         dstPoolDriver=zfs # Use ZFS storage pool as that has fixed volumes not files.
         if [ "${poolDriver}" = "zfs" ]; then
@@ -357,11 +376,6 @@ do
         [ $(($(lxc exec v2 -- blockdev --getsize64 /dev/sda)/${GiB})) -eq "7" ]
         lxc delete -f v2
 
-        echo "==> Copy to different storage pool with same driver"
-        lxc storage create "${poolName}3" "${poolDriver}"
-        lxc copy v1 v2 -s "${poolName}3"
-        lxc delete -f v2
-
         echo "==> Grow above default volume size and copy to different storage pool"
         lxc config device override v1 root size=11GiB
         lxc copy v1 v2 -s "${poolName}2"
@@ -372,6 +386,7 @@ do
         echo "==> Checking copied VM root disk size is 11GiB"
         [ $(($(lxc exec v2 -- blockdev --getsize64 /dev/sda)/${GiB})) -eq "11" ]
         lxc delete -f v2
+        lxc storage delete "${poolName}2"
 
         echo "==> Publishing larger VM"
         lxc start v1 # Start to ensure cloud-init grows filesystem before publish.
@@ -405,8 +420,6 @@ do
         lxc profile delete vmsmall
 
         echo "==> Deleting storage pool"
-        lxc storage delete "${poolName}3"
-        lxc storage delete "${poolName}2"
         lxc storage delete "${poolName}"
 done
 


### PR DESCRIPTION
Since https://github.com/lxc/lxc-ci/pull/536

Also simplifies pool creation logic and deletes unused pools earlier.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>