### PR TITLE
jenkins/jobs/voidlinux: Update mirror

### DIFF
--- a/jenkins/jobs/image-voidlinux.yaml
+++ b/jenkins/jobs/image-voidlinux.yaml
@@ -42,13 +42,13 @@
                 ${LXD_ARCHITECTURE} container 1800 ${WORKSPACE} \
                 -o image.architecture=${ARCH} -o image.release=${release} \
                 -o image.variant=${variant} -o source.variant=${variant} \
-                -o source.url="https://repo-us.voidlinux.org/live/current/"
+                -o source.url="https://mirrors.servercentral.com/voidlinux/current/"
         fi
 
         exec sudo /lxc-ci/bin/build-distro /lxc-ci/images/voidlinux.yaml \
             ${LXD_ARCHITECTURE} container 1800 ${WORKSPACE} \
             -o image.architecture=${ARCH} -o image.release=${release} \
-            -o source.url="https://repo-us.voidlinux.org/live/current/"
+            -o source.url="https://mirrors.servercentral.com/voidlinux/current/"
 
     properties:
     - build-discarder:


### PR DESCRIPTION
This uses a mirror which supports IPv6.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
