### PR TITLE
Add openSUSE Leap 15.4

### DIFF
--- a/images/opensuse.yaml
+++ b/images/opensuse.yaml
@@ -107,6 +107,7 @@ files:
   - vm
   releases:
   - 15.3
+  - 15.4
 
 - name: ifcfg-enp5s0
   path: /etc/sysconfig/network/ifcfg-enp5s0
@@ -155,6 +156,15 @@ files:
   - vm
   releases:
   - 15.3
+
+- path: /etc/dracut.conf.d/lxd.conf
+  generator: dump
+  content: |-
+    add_drivers+=" virtio_scsi virtio_pci sd_mod "
+  types:
+  - vm
+  releases:
+  - 15.4
 
 - path: /etc/fstab
   generator: dump

--- a/images/opensuse.yaml
+++ b/images/opensuse.yaml
@@ -104,7 +104,6 @@ files:
     STARTMODE='auto'
     BOOTPROTO='dhcp'
   types:
-  - container
   - vm
   releases:
   - 15.3

--- a/jenkins/jobs/image-opensuse.yaml
+++ b/jenkins/jobs/image-opensuse.yaml
@@ -21,6 +21,7 @@
         type: user-defined
         values:
         - "15.3"
+        - "15.4"
         - "tumbleweed"
 
     - axis:


### PR DESCRIPTION
- images/opensuse: Drop duplicate ifcfg-eth0 for containers
- images/opensuse: Support Leap 15.4
- jenkins/jobs/opensuse: Add Leap 15.4
