### PR TITLE
images/funtoo: Fix networking

### DIFF
--- a/images/funtoo.yaml
+++ b/images/funtoo.yaml
@@ -276,9 +276,9 @@ actions:
     rm -rf /var/cache/portage
 
     cd /etc/init.d
-    ln -s netif.tmpl net.eth0
-    rc-update add net.eth0 default
-    echo template=dhcpcd > /etc/conf.d/net.eth0
+    ln -s netif.tmpl netif.eth0
+    rc-update add netif.eth0 default
+    echo template=dhcpcd > /etc/conf.d/netif.eth0
 
 mappings:
   architecture_map: funtoo


### PR DESCRIPTION
This changes net.eth0 to netif.eth0 as the naming is important according
to the official documentation.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
