### PR TITLE
images/alt: Update mirror

### DIFF
--- a/images/alt.yaml
+++ b/images/alt.yaml
@@ -3,7 +3,7 @@ image:
 
 source:
   downloader: alt-http
-  url: http://ftp.altlinux.org/pub/distributions/ALTLinux/images
+  url: https://mirror.yandex.ru/altlinux/images
   keys:
   # 0x17F112840DE94827C9C109FD3E2B30EA57EF33CE
   - |-


### PR DESCRIPTION
Use a mirror which supports IPv6.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
