### PR TITLE
images/centos: Change mirror for 7/i386

### DIFF
--- a/images/centos.yaml
+++ b/images/centos.yaml
@@ -689,6 +689,7 @@ actions:
   - 7
   architectures:
   - x86_64
+  - i386
 
 - trigger: post-unpack
   action: |-


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
