### PR TITLE
images/opensuse: Use dracut for all VMs

### DIFF
--- a/images/opensuse.yaml
+++ b/images/opensuse.yaml
@@ -165,6 +165,7 @@ files:
   - vm
   releases:
   - 15.4
+  - tumbleweed
 
 - path: /etc/fstab
   generator: dump
@@ -390,7 +391,7 @@ actions:
     rm /etc/resolv.conf
     ln -sf /var/run/netconfig/resolv.conf /etc/resolv.conf
 
-    mkinitrd
+    dracut --regenerate-all --force
     mount -t tmpfs tmpfs /sys/firmware
     mkdir /sys/firmware/efi
     grub2-mkconfig -o /boot/grub2/grub.cfg


### PR DESCRIPTION
This fixes an issue in Tumbleweed where it wouldn't accept mkinitrd.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
