### PR TITLE
images/archlinux: Fix first boot wizard

### DIFF
--- a/images/archlinux.yaml
+++ b/images/archlinux.yaml
@@ -662,6 +662,13 @@ actions:
     echo en_US.UTF-8 UTF-8 > /etc/locale.gen
     locale-gen
     echo LANG=en_US.UTF-8 > /etc/locale.conf
+  types:
+  - vm
+
+- trigger: post-packages
+  action: |-
+    #!/bin/sh
+    set -eux
 
     # User
     USERNAME="archlinux"


### PR DESCRIPTION
The first boot wizard prompts for timezone info during boot if not set,
and fails after some time.

This fixes the issue by setting timezone and locale the wizard is run.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
