### PR TITLE
jenkins/jobs: Fix Alpine edge builds

### DIFF
--- a/jenkins/jobs/image-alpine.yaml
+++ b/jenkins/jobs/image-alpine.yaml
@@ -49,10 +49,15 @@
             TYPE="container,vm"
         fi
 
+        EXTRA_ARGS=""
+        if [ "${release}" = "edge" ]; then
+            EXTRA_ARGS="-o source.same_as=3.16"
+        fi
+
         exec sudo /lxc-ci/bin/build-distro /lxc-ci/images/alpine.yaml \
             ${LXD_ARCHITECTURE} ${TYPE} 600 ${WORKSPACE} \
             -o image.architecture=${ARCH} -o image.release=${release} \
-            -o image.variant=${variant}
+            -o image.variant=${variant} ${EXTRA_ARGS}
 
     execution-strategy:
       combination-filter: '


### PR DESCRIPTION
Alpine edge signing keys have been rotated.

This fix gets the correct keys into the edge build.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
