### PR TITLE
images/debian: Use search domains from DHCP

### DIFF
--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -933,6 +933,8 @@ files:
     Name=eth0
     [Network]
     DHCP=true
+    [DHCPv4]
+    UseDomains=true
   types:
   - container
   releases:
@@ -947,6 +949,8 @@ files:
     Name=enp5s0
     [Network]
     DHCP=true
+    [DHCPv4]
+    UseDomains=true
   types:
   - vm
   variants:


### PR DESCRIPTION
Configure the 'systemd-networkd' service to accept 'domain' and 'search'
DHCP options during network configuration. This ensures that the
'systemd-networkd' service has the same functionality as the 'ifupdown'
service and domain name resolution in LXC containers works as expected
in environments with their own DNS domains.

Signed-off-by: Maciej Delmanowski <drybjed@drybjed.net>