### PR TITLE
images/archlinux: Update archlinux-keyring first

### DIFF
--- a/images/archlinux.yaml
+++ b/images/archlinux.yaml
@@ -636,6 +636,15 @@ packages:
     - desktop-gnome
 
 actions:
+- trigger: post-unpack
+  action: |-
+    #!/bin/sh
+    set -eux
+
+    # Update pacman-keyring to ensure package installs will not break because of GPG issues
+    pacman -Sy --needed
+     --noconfirm archlinux-keyring
+
 - trigger: post-packages
   action: |-
     #!/bin/sh


### PR DESCRIPTION
This causes archlinux-keyring to be installed/updated first which should
remove any GPG related issues when installing other packages.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
