### PR TITLE
images/alpine: Temporarily disable 3.16

### DIFF
--- a/jenkins/jobs/image-alpine.yaml
+++ b/jenkins/jobs/image-alpine.yaml
@@ -24,7 +24,8 @@
         - "3.13"
         - "3.14"
         - "3.15"
-        - "3.16"
+        # TODO: Enable this once the package issue has been fixed upstream.
+        # - "3.16"
         - "edge"
 
     - axis:


### PR DESCRIPTION
In 3.16 there is a missing package which is required by alpine-base.
Until this issue has been fixed, the build will be disabled.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
