### PR TITLE
debian.yaml: don't install acpid

### DIFF
--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -1056,7 +1056,6 @@ packages:
     - cloud
 
   - packages:
-    - acpid
     - policykit-1
     action: install
     architectures:


### PR DESCRIPTION
Systemd listens and reacts to ACPI events.

Signed-off-by: Simon Deziel <simon.deziel@canonical.com>