### PR TITLE
images/alpine: Install cloud-init dependencies

### DIFF
--- a/images/alpine.yaml
+++ b/images/alpine.yaml
@@ -334,6 +334,15 @@ packages:
     - cloud
 
   - packages:
+    - py3-pyserial
+    - py3-netifaces
+    action: install
+    variants:
+    - cloud
+    releases:
+    - edge
+
+  - packages:
     - acpi
     - gcc
     - grub-efi


### PR DESCRIPTION
This installs the Python modules 'serial' and 'netifaces' which are
required by cloud-init but aren't installed alongside cloud-init in
the edge release.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
