### PR TITLE
images/ubuntu: Temporarily drop language-pack-en for focal/ppc64el

### DIFF
--- a/images/ubuntu.yaml
+++ b/images/ubuntu.yaml
@@ -492,11 +492,31 @@ packages:
     action: install
 
   - packages:
-    - language-pack-en
     - openssh-client
     - sudo
     - vim
     action: install
+
+  - packages:
+    - language-pack-en
+    action: install
+    architectures:
+    - amd64
+    - arm64
+    - armhf
+    - powerpc
+    - powerpc64
+
+  - packages:
+    - language-pack-en
+    action: install
+    architectures:
+    - ppc64el
+    releases:
+    - xenial
+    - bionic
+    - jammy
+    - kinetic
 
   - packages:
     - cloud-init


### PR DESCRIPTION
This temporarily disables the package-pack-en package for
focal/ppc64el due to unmet dependencies.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
