### PR TITLE
bin/build-cache-lxd: Use curl instead of wget

### DIFF
--- a/bin/build-cache-lxd
+++ b/bin/build-cache-lxd
@@ -101,9 +101,9 @@ arch="$(dpkg --print-architecture)"
 
 # Download MinIO binary
 if [ "${arch}" = "amd64" ]; then
-    wget https://dl.min.io/server/minio/release/linux-amd64/minio -o "${GOPATH}/minio"
+    curl --no-progress-meter https://dl.min.io/server/minio/release/linux-amd64/minio -o "${GOPATH}/minio"
 elif [ "${arch}" = "arm64" ]; then
-    wget https://dl.min.io/server/minio/release/linux-arm64/minio -o "${GOPATH}/minio"
+    curl --no-progress-meter https://dl.min.io/server/minio/release/linux-arm64/minio -o "${GOPATH}/minio"
 fi
 
 OLD_PATH=${PATH}


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>