### PR TITLE
bin/build-cache-lxd: Support curl in Focal

### DIFF
--- a/bin/build-cache-lxd
+++ b/bin/build-cache-lxd
@@ -101,9 +101,9 @@ arch="$(dpkg --print-architecture)"
 
 # Download MinIO binary
 if [ "${arch}" = "amd64" ]; then
-    curl --no-progress-meter https://dl.min.io/server/minio/release/linux-amd64/minio -o "${GOPATH}/minio"
+    curl --silent --show-error https://dl.min.io/server/minio/release/linux-amd64/minio -o "${GOPATH}/minio"
 elif [ "${arch}" = "arm64" ]; then
-    curl --no-progress-meter https://dl.min.io/server/minio/release/linux-arm64/minio -o "${GOPATH}/minio"
+    curl --silent --show-error https://dl.min.io/server/minio/release/linux-arm64/minio -o "${GOPATH}/minio"
 fi
 
 OLD_PATH=${PATH}


### PR DESCRIPTION
`--no-progress-meter` doesn't exist in Focal's version of curl apparently.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>