### PR TITLE
bin/build-cache-lxd: Fix xgettext-go caching

### DIFF
--- a/bin/build-cache-lxd
+++ b/bin/build-cache-lxd
@@ -115,7 +115,7 @@ for version in 1.13 1.17 1.18 tip; do
 
     for pkg in github.com/rogpeppe/godeps \
                github.com/tsenart/deadcode \
-               github.com/snapcore/snapd/i18n/xgettext-go \
+               github.com/snapcore/snapd/i18n/xgettext-go@2.57.1 \
                github.com/client9/misspell/cmd/misspell \
                github.com/gordonklaus/ineffassign \
                golang.org/x/lint/golint; do


### PR DESCRIPTION
I noticed that the artifact build had this error:

```
 go install github.com/snapcore/snapd/i18n/xgettext-go@latest
go: downloading github.com/snapcore/snapd v0.0.0-20220905170714-061c192e0d39
go install: github.com/snapcore/snapd/i18n/xgettext-go@latest (in github.com/snapcore/snapd@v0.0.0-20220905170714-061c192e0d39):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```

This PR pins the `xgettext-go` to `2.57.1` the same as https://github.com/lxc/lxd/commit/033ae33cba1d6d989a212445c41610287b32c280

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>