### PR TITLE
images/debian: Drop resolvconf on bookworm/cloud

### DIFF
--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -1071,7 +1071,6 @@ packages:
     releases:
     - buster
     - bullseye
-    - bookworm
 
   - packages:
     - policykit-1


### PR DESCRIPTION
This drops the resolvconf pacakge for bookworm/cloud as it causes a
conflict with systemd-resolved.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
