### PR TITLE
images/fedora: Update mirror

### DIFF
--- a/images/fedora.yaml
+++ b/images/fedora.yaml
@@ -247,7 +247,7 @@ actions:
     for repo in $(ls /etc/yum.repos.d/*.repo); do
       grep -q '^#baseurl' "${repo}" || continue
 
-      sed -ri 's/^metalink=.*/#\0/g;s@^#(baseurl=)http://download.example/pub(.*)@\1https://muug.ca/mirror\2@g' "${repo}"
+      sed -ri 's/^metalink=.*/#\0/g;s@^#(baseurl=)http://download.example/pub(.*)@\1https://mirror.csclub.uwaterloo.ca/\2@g' "${repo}"
     done
   architectures:
   - aarch64


### PR DESCRIPTION
This updates the mirror due to connection issues with the previous one.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
