### PR TITLE
bin/test-lxd-kernel: Skip storage_buckets tests

### DIFF
--- a/bin/test-lxd-kernel
+++ b/bin/test-lxd-kernel
@@ -76,4 +76,4 @@ fi
 # Run tests
 cd /root/go/src/github.com/lxc/lxd/test
 uname -a
-LXD_SKIP_STATIC=1 LXD_OFFLINE=0 LXD_TMPFS=1 LXD_VERBOSE=1 time -p ./main.sh
+LXD_SKIP_STATIC=1 LXD_SKIP_TESTS=storage_buckets LXD_OFFLINE=0 LXD_TMPFS=1 LXD_VERBOSE=1 time -p ./main.sh


### PR DESCRIPTION
No need to check storage buckets support for kernel tests. Also remove unused LXD_SKIP_STATIC setting.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>