### PR TITLE
images/rockylinux: Drop s390x

### DIFF
--- a/jenkins/jobs/image-rockylinux.yaml
+++ b/jenkins/jobs/image-rockylinux.yaml
@@ -13,7 +13,6 @@
         - amd64
         - arm64
         - ppc64el
-        - s390x
 
     - axis:
         name: release
@@ -53,8 +52,7 @@
 
     execution-strategy:
       combination-filter: '
-      !(release!="9" && architecture == "ppc64el") &&
-      !(release!="9" && architecture == "s390x")'
+      !(release!="9" && architecture == "ppc64el")'
 
     properties:
     - build-discarder:


### PR DESCRIPTION
This drops s390x support due to

    Fatal glibc error: CPU lacks VXE support (z14 or later required)

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
