### PR TITLE
images/ubuntu: Symlink /etc/resolv.conf

### DIFF
--- a/images/ubuntu.yaml
+++ b/images/ubuntu.yaml
@@ -662,6 +662,16 @@ actions:
     #!/bin/sh
     set -eux
 
+    # Ensure /etc/resolv.conf is symlinked to /run/systemd/resolve/stub-resolv.conf
+    ln -sf ../run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
+  releases:
+  - kinetic
+
+- trigger: post-packages
+  action: |-
+    #!/bin/sh
+    set -eux
+
     # Make sure the locale is built and functional
     locale-gen en_US.UTF-8
     update-locale LANG=en_US.UTF-8


### PR DESCRIPTION
This doesn't fix anything but rather keeps things consistent. On
releases prior to kinetic, /etc/resolv.conf is symlinked to
/run/systemd/resolve/stub-resolv.conf. Since systemd-resolved is a
separate package on kinetic and newer releases, this symlink is not
automatically created.

This ensures /etc/resolv.conf is correctly symlinked, and therefore not
empty.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
