### PR TITLE
bin/test-lxd-storage-buckets: Use eval for contents of  http://canonical-lxd.stgraber.org/config/ceph.sh

### DIFF
--- a/bin/test-lxd-storage-buckets
+++ b/bin/test-lxd-storage-buckets
@@ -37,7 +37,7 @@ waitSnapdSeed
 curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh
 
 # Configure for ceph use
-curl -s http://canonical-lxd.stgraber.org/config/ceph.sh | sh
+eval "$(curl -s http://canonical-lxd.stgraber.org/config/ceph.sh)"
 
 # Install LXD
 while [ -e /usr/bin/lxd ]; do


### PR DESCRIPTION
So that the env vars in that file are exported into the test script.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>