### PR TITLE
lxd-test-network-ovn: Switch to jammy

### DIFF
--- a/jenkins/jobs/lxd-test-network-ovn-acl.yaml
+++ b/jenkins/jobs/lxd-test-network-ovn-acl.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/maas-run tags=virtual focal ga-20.04 default bin/test-lxd-network-ovn-acl
+        exec sudo /lxc-ci/bin/maas-run tags=virtual focal ga-22.04 default bin/test-lxd-network-ovn-acl
 
     properties:
     - build-discarder:

--- a/jenkins/jobs/lxd-test-network-ovn.yaml
+++ b/jenkins/jobs/lxd-test-network-ovn.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/maas-run tags=virtual focal ga-20.04 default bin/test-lxd-network-ovn
+        exec sudo /lxc-ci/bin/maas-run tags=virtual focal ga-22.04 default bin/test-lxd-network-ovn
 
     properties:
     - build-discarder:


### PR DESCRIPTION
Lets see if Jammy is behaving better with OVN now (seems better locally).

Fixes #490

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>