### PR TITLE
bin/test-lxd-storage-buckets: Set ceph.external=true for cephobject bucket support

### DIFF
--- a/bin/test-lxd-storage-buckets
+++ b/bin/test-lxd-storage-buckets
@@ -46,6 +46,7 @@ done
 apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
+snap set lxd ceph.external=true
 apt-get install jq --yes
 lxd waitready --timeout=300
 


### PR DESCRIPTION


Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>