### PR TITLE
bin/test-lxd-storage-buckets: Install ceph-common to get radosgw-admin command

### DIFF
--- a/bin/test-lxd-storage-buckets
+++ b/bin/test-lxd-storage-buckets
@@ -47,7 +47,7 @@ apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
 snap set lxd ceph.external=true
-apt-get install jq --yes
+apt-get install jq ceph-common --yes
 lxd waitready --timeout=300
 
 # Configure LXD


### PR DESCRIPTION


Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>