### PR TITLE
jenkins/jobs/lxd-test-network-ovn: Jammy OVN still broken, using Focal instead

### DIFF
--- a/jenkins/jobs/lxd-test-network-ovn.yaml
+++ b/jenkins/jobs/lxd-test-network-ovn.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/maas-run tags=virtual jammy ga-22.04 default bin/test-lxd-network-ovn
+        exec sudo /lxc-ci/bin/maas-run tags=virtual focal ga-20.04 default bin/test-lxd-network-ovn
 
     properties:
     - build-discarder:


### PR DESCRIPTION


Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>