### PR TITLE
jenkins/jobs: Temporarily disable openSUSE tumbleweed/cloud/s390x

### DIFF
--- a/jenkins/jobs/image-opensuse.yaml
+++ b/jenkins/jobs/image-opensuse.yaml
@@ -56,7 +56,9 @@
             -o image.variant=${variant}
 
     execution-strategy:
-      combination-filter: '!(architecture != "amd64" && variant == "desktop-kde")'
+      combination-filter: '
+      !(architecture != "amd64" && variant == "desktop-kde") &&
+      !(architecture == "s390x" && variant == "cloud" && release == "tumbleweed")'
 
     properties:
     - build-discarder:


### PR DESCRIPTION
Temporarily disable the openSUSE tumbleweed/cloud image for s390x due
to a package conflict.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
