### PR TITLE
jenkins/jobs: Temporarily disable Gentoo cloud images

### DIFF
--- a/jenkins/jobs/image-gentoo.yaml
+++ b/jenkins/jobs/image-gentoo.yaml
@@ -26,7 +26,8 @@
         type: user-defined
         values:
         - openrc
-        - cloud
+        # TODO: include cloud images once build issues have been resolved
+        # - cloud
         - systemd
 
     builders:


### PR DESCRIPTION
This temporarily disables Gentoo cloud images due to unknown build
issues.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
