### PR TITLE
images: Drop systemd-binfmt mask

### DIFF
--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -1297,16 +1297,6 @@ actions:
     #!/bin/sh
     set -eux
 
-    # Mask systemd-binfmt service to ensure it's not called
-    systemctl mask systemd-binfmt.service
-  types:
-  - container
-
-- trigger: post-packages
-  action: |-
-    #!/bin/sh
-    set -eux
-
     # Make sure the locale is built and functional
     echo en_US.UTF-8 UTF-8 >> /etc/locale.gen
     locale-gen en_US.UTF-8 UTF-8

--- a/images/gentoo.yaml
+++ b/images/gentoo.yaml
@@ -606,12 +606,6 @@ actions:
 
     systemctl enable systemd-resolved
     systemctl enable systemd-networkd
-
-    # Disable systemd-binfmt as it doesn't work in containers
-    systemctl disable systemd-binfmt.timer
-
-    # Mask systemd-binfmt service to ensure it's not called
-    systemctl mask systemd-binfmt.service
   variants:
   - systemd
 

--- a/images/kali.yaml
+++ b/images/kali.yaml
@@ -1778,15 +1778,5 @@ actions:
   variants:
   - cloud
 
-- trigger: post-packages
-  action: |-
-    #!/bin/sh
-    set -eux
-
-    # Mask systemd-binfmt service to ensure it's not called
-    systemctl mask systemd-binfmt.service
-  types:
-  - container
-
 mappings:
   architecture_map: debian


### PR DESCRIPTION
This removes the system-binfmt.service mask as the systemd-generator now
takes care of that.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
