### PR TITLE
Add missing FAIL=0 to test-lxd-cpu-vm

### DIFF
--- a/bin/test-lxd-cpu-vm
+++ b/bin/test-lxd-cpu-vm
@@ -120,3 +120,5 @@ lxc config unset v1 limits.cpu
 
 # Unsetting the limit should leave the VM with 1 CPU
 [ "$(lxc exec v1 -- ls /sys/devices/system/cpu | grep -Ec 'cpu[[:digit:]]+')" -eq "1" ]
+
+FAIL=0


### PR DESCRIPTION
This needs to be added otherwise the test will always fail.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
