### PR TITLE
build-distro: increase build tmpfs to 6G and include openEuler

### DIFF
--- a/bin/build-distro
+++ b/bin/build-distro
@@ -57,8 +57,8 @@ snap refresh distrobuilder || true
 # Build the image
 mkdir /root/build /root/build/cache
 if [ "$(uname -m)" = "x86_64" ] || [ "$(uname -m)" = "i686" ]; then
-    if ! echo "${YAML}" | grep -q -E "sabayon|gentoo|oracle|springdalelinux" && [ "${TYPE}" != "vm" ]; then
-        mount -t tmpfs tmpfs /root/build -o size=5G,nr_inodes=10000000
+    if ! echo "${YAML}" | grep -q -E "sabayon|gentoo|oracle|springdalelinux|openeuler" && [ "${TYPE}" != "vm" ]; then
+        mount -t tmpfs tmpfs /root/build -o size=6G,nr_inodes=10000000
     fi
 fi
 mv /root/image.yaml /root/build/


### PR DESCRIPTION
This increases the size of the tmpfs to 6G as 5G wasn't enough for
openEuler.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
