### PR TITLE
bin/test-lxd-storage-vm: Don't quote GiB var inside arithmetic operator

### DIFF
--- a/bin/test-lxd-storage-vm
+++ b/bin/test-lxd-storage-vm
@@ -110,7 +110,7 @@ do
         lxc exec v1 -- umount /srv
 
         echo "==> Checking VM root disk size is 10GiB"
-        [ $(($(lxc exec v1 -- blockdev --getsize64 /dev/sda)/"${GiB}")) -eq "10" ]
+        [ $(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB)) -eq "10" ]
 
         echo "foo" | lxc exec v1 -- tee /root/foo.txt
         lxc exec v1 -- sync
@@ -128,7 +128,7 @@ do
         lxc exec v2 -- cat /root/foo.txt | grep -Fx "foo"
 
         echo "==> Checking VM snapshot copy root disk size is 10GiB"
-        [ $(($(lxc exec v2 -- blockdev --getsize64 /dev/sda)/"${GiB}")) -eq "10" ]
+        [ $(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB)) -eq "10" ]
         lxc delete -f v2
         lxc delete v1/snap0
 
@@ -172,7 +172,7 @@ do
         waitVMAgent v1
 
         echo "==> Checking VM root disk size is 11GiB"
-        [ $(($(lxc exec v1 -- blockdev --getsize64 /dev/sda)/"${GiB}")) -eq "11" ]
+        [ $(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB)) -eq "11" ]
 
         echo "==> Check VM shrink is blocked"
         ! lxc config device set v1 root size=10GiB || false
@@ -305,7 +305,7 @@ do
         lxc info v1
 
         echo "==> Checking VM root disk size is 6GiB"
-        [ $(($(lxc exec v1 -- blockdev --getsize64 /dev/sda)/"${GiB}")) -eq "6" ]
+        [ $(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB)) -eq "6" ]
 
         echo "==> Deleting VM and reset pool volume.size"
         lxc delete -f v1
@@ -337,7 +337,7 @@ do
         lxc info v1
 
         echo "==> Checking VM root disk size is 7GiB"
-        [ $(($(lxc exec v1 -- blockdev --getsize64 /dev/sda)/"${GiB}")) -eq "7" ]
+        [ $(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB)) -eq "7" ]
         lxc stop -f v1
 
         echo "==> Copy to different storage pool with same driver and check size"
@@ -357,7 +357,7 @@ do
         lxc info v2
 
         echo "==> Checking copied VM root disk size is 7GiB"
-        [ $(($(lxc exec v2 -- blockdev --getsize64 /dev/sda)/"${GiB}")) -eq "7" ]
+        [ $(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB)) -eq "7" ]
         lxc delete -f v2
         lxc storage delete "${poolName}2"
 
@@ -374,7 +374,7 @@ do
         lxc info v2
 
         echo "==> Checking copied VM root disk size is 7GiB"
-        [ $(($(lxc exec v2 -- blockdev --getsize64 /dev/sda)/"${GiB}")) -eq "7" ]
+        [ $(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB)) -eq "7" ]
         lxc delete -f v2
 
         echo "==> Grow above default volume size and copy to different storage pool"
@@ -385,7 +385,7 @@ do
         lxc info v2
 
         echo "==> Checking copied VM root disk size is 11GiB"
-        [ $(($(lxc exec v2 -- blockdev --getsize64 /dev/sda)/"${GiB}")) -eq "11" ]
+        [ $(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB)) -eq "11" ]
         lxc delete -f v2
         lxc storage delete "${poolName}2"
 
@@ -409,7 +409,7 @@ do
         lxc info v1
 
         echo "==> Checking new VM root disk size is 11GiB"
-        [ $(($(lxc exec v1 -- blockdev --getsize64 /dev/sda)/"${GiB}")) -eq "11" ]
+        [ $(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB)) -eq "11" ]
 
         echo "===> Renaming VM"
         lxc stop -f v1


### PR DESCRIPTION
The GiB var is used inside the shell arithmetic operatior ((..)), there is no need to quote or even use the $ prefix.

Fixes the issue introduced by commit c9e7b41aa606a75f8