### PR TITLE
images/alpine: Add missing Python modules on 3.17

### DIFF
--- a/images/alpine.yaml
+++ b/images/alpine.yaml
@@ -340,6 +340,7 @@ packages:
     variants:
     - cloud
     releases:
+    - 3.17
     - edge
 
   - packages:


### PR DESCRIPTION
This fixes cloud-init which complains about missing Python modules.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
