### PR TITLE
images: Use docker-http for openeuler

### DIFF
--- a/images/openeuler.yaml
+++ b/images/openeuler.yaml
@@ -3,11 +3,7 @@ image:
   description: |-
     openEuler {{ image.release }}
 source:
-  downloader: openeuler-http
-  url: https://ru-repo.openeuler.org
-  # also supported by docker
-  # downloader: docker-http
-  # url: openeuler/openeuler:22.03
+  downloader: docker-http
 targets:
   lxc:
     create_message: |

--- a/jenkins/jobs/image-openeuler.yaml
+++ b/jenkins/jobs/image-openeuler.yaml
@@ -45,7 +45,7 @@
         exec sudo /lxc-ci/bin/build-distro /lxc-ci/images/openeuler.yaml \
             ${LXD_ARCHITECTURE} ${TYPE} 7200 ${WORKSPACE} \
             -o image.architecture=${ARCH} -o image.release=${release} \
-            -o image.variant=${variant} ${EXTRA_ARGS}
+            -o image.variant=${variant} -o source.url="openeuler/openeuler:${release}" ${EXTRA_ARGS}
 
     properties:
     - build-discarder:


### PR DESCRIPTION
This uses the docker-http downloader for openeuler images as the
openeuler mirrors are rather unreliable.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
