### PR TITLE
jenkins/jobs: Drop Fedora armhf builds

### DIFF
--- a/jenkins/jobs/image-fedora.yaml
+++ b/jenkins/jobs/image-fedora.yaml
@@ -12,7 +12,6 @@
         values:
         - amd64
         - arm64
-        - armhf
         - ppc64el
         - s390x
 
@@ -39,7 +38,6 @@
         ARCH=${architecture}
         [ "${ARCH}" = "amd64" ] && ARCH="x86_64"
         [ "${ARCH}" = "arm64" ] && ARCH="aarch64"
-        [ "${ARCH}" = "armhf" ] && ARCH="armhfp"
         [ "${ARCH}" = "ppc64el" ] && ARCH="ppc64le"
 
         TYPE="container"
@@ -51,10 +49,6 @@
             ${LXD_ARCHITECTURE} ${TYPE} 1800 ${WORKSPACE} \
             -o image.architecture=${ARCH} -o image.release=${release} \
             -o image.variant=${variant}
-
-    execution-strategy:
-      combination-filter: '
-      !(architecture == "armhf" && release != "36")'
 
     properties:
     - build-discarder:


### PR DESCRIPTION
Fedora no longer provides armhf images.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
