### PR TITLE
images/openeuler: Rebuild rpm database after unpack

### DIFF
--- a/images/openeuler.yaml
+++ b/images/openeuler.yaml
@@ -312,6 +312,14 @@ actions:
 - trigger: post-unpack
   action: |-
     #!/bin/sh
+    set -eux
+
+    # Rebuild rpm database as the failing builds suggest it's broken.
+    rpmdb --rebuilddb
+
+- trigger: post-unpack
+  action: |-
+    #!/bin/sh
     # Generate machine-id in order for the kernel stuff to be configured properly
     systemd-machine-id-setup
   types:


### PR DESCRIPTION
The build failures suggest that the rpm database is broken or corrupted.
Rebuilding the database fixes the builds.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
