### PR TITLE
jenkins/jobs: maas-run shouldn't need sudo

### DIFF
--- a/jenkins/jobs/lxd-cloud-test.yaml
+++ b/jenkins/jobs/lxd-cloud-test.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/maas-run tags=virtual jammy ga-22.04 default bin/test-lxd-cloud
+        exec /lxc-ci/bin/maas-run tags=virtual jammy ga-22.04 default bin/test-lxd-cloud
 
     properties:
     - build-discarder:

--- a/jenkins/jobs/lxd-test-devlxd-vm.yaml
+++ b/jenkins/jobs/lxd-test-devlxd-vm.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/maas-run tags=physical jammy ga-22.04 default bin/test-lxd-devlxd-vm
+        exec /lxc-ci/bin/maas-run tags=physical jammy ga-22.04 default bin/test-lxd-devlxd-vm
 
     properties:
     - build-discarder:

--- a/jenkins/jobs/lxd-test-gpu.yaml
+++ b/jenkins/jobs/lxd-test-gpu.yaml
@@ -30,19 +30,19 @@
     - shell: |-
         cd /lxc-ci
         if [ "${platform}" = "nvidia" ] && [ "${target}" = "container" ]; then
-            exec sudo /lxc-ci/bin/maas-run name=vm12 jammy ga-22.04 nvidia bin/test-lxd-gpu-container
+            exec /lxc-ci/bin/maas-run name=vm12 jammy ga-22.04 nvidia bin/test-lxd-gpu-container
         fi
 
         if [ "${platform}" = "nvidia" ] && [ "${target}" = "mig" ]; then
-            exec sudo /lxc-ci/bin/maas-run name=argos jammy ga-22.04 nvidia-mig bin/test-lxd-gpu-mig
+            exec /lxc-ci/bin/maas-run name=argos jammy ga-22.04 nvidia-mig bin/test-lxd-gpu-mig
         fi
 
         if [ "${platform}" = "nvidia" ] && [ "${target}" = "vm" ]; then
-            exec sudo /lxc-ci/bin/maas-run name=argos focal ga-20.04 iommu,nvidia-vgpu bin/test-lxd-gpu-vm nvidia
+            exec /lxc-ci/bin/maas-run name=argos focal ga-20.04 iommu,nvidia-vgpu bin/test-lxd-gpu-vm nvidia
         fi
 
         if [ "${platform}" = "amd" ] && [ "${target}" = "vm" ]; then
-            exec sudo /lxc-ci/bin/maas-run name=lantea jammy ga-22.04 iommu,amd-vgpu bin/test-lxd-gpu-vm amd
+            exec /lxc-ci/bin/maas-run name=lantea jammy ga-22.04 iommu,amd-vgpu bin/test-lxd-gpu-vm amd
         fi
 
     execution-strategy:

--- a/jenkins/jobs/lxd-test-images.yaml
+++ b/jenkins/jobs/lxd-test-images.yaml
@@ -24,9 +24,9 @@
     - shell: |-
         cd /lxc-ci
         if [ "${type}" = "vm" ]; then
-            exec sudo /lxc-ci/bin/maas-run name=lantea jammy ga-22.04 default bin/test-lxd-images "${type}"
+            exec /lxc-ci/bin/maas-run name=lantea jammy ga-22.04 default bin/test-lxd-images "${type}"
         else
-            exec sudo /lxc-ci/bin/maas-run tags=lxd-images jammy ga-22.04 default bin/test-lxd-images "${type}"
+            exec /lxc-ci/bin/maas-run tags=lxd-images jammy ga-22.04 default bin/test-lxd-images "${type}"
         fi
 
     properties:

--- a/jenkins/jobs/lxd-test-interception.yaml
+++ b/jenkins/jobs/lxd-test-interception.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/maas-run tags=virtual jammy ga-22.04 default bin/test-lxd-interception
+        exec /lxc-ci/bin/maas-run tags=virtual jammy ga-22.04 default bin/test-lxd-interception
 
     properties:
     - build-discarder:

--- a/jenkins/jobs/lxd-test-lxd-cpu-vm.yaml
+++ b/jenkins/jobs/lxd-test-lxd-cpu-vm.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/maas-run tags=physical jammy ga-22.04 default bin/test-lxd-cpu-vm
+        exec /lxc-ci/bin/maas-run tags=physical jammy ga-22.04 default bin/test-lxd-cpu-vm
 
     properties:
     - build-discarder:

--- a/jenkins/jobs/lxd-test-maas.yaml
+++ b/jenkins/jobs/lxd-test-maas.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/maas-run tags=virtual jammy ga-22.04 default bin/test-lxd-maas
+        exec /lxc-ci/bin/maas-run tags=virtual jammy ga-22.04 default bin/test-lxd-maas
 
     properties:
     - build-discarder:

--- a/jenkins/jobs/lxd-test-network-bridge-firewall.yaml
+++ b/jenkins/jobs/lxd-test-network-bridge-firewall.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/maas-run tags=virtual jammy ga-22.04 default bin/test-lxd-network-bridge-firewall
+        exec /lxc-ci/bin/maas-run tags=virtual jammy ga-22.04 default bin/test-lxd-network-bridge-firewall
 
     properties:
     - build-discarder:

--- a/jenkins/jobs/lxd-test-network-ovn-acl.yaml
+++ b/jenkins/jobs/lxd-test-network-ovn-acl.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/maas-run tags=virtual jammy ga-22.04 default bin/test-lxd-network-ovn-acl
+        exec /lxc-ci/bin/maas-run tags=virtual jammy ga-22.04 default bin/test-lxd-network-ovn-acl
 
     properties:
     - build-discarder:

--- a/jenkins/jobs/lxd-test-network-ovn.yaml
+++ b/jenkins/jobs/lxd-test-network-ovn.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/maas-run tags=virtual focal ga-20.04 default bin/test-lxd-network-ovn
+        exec /lxc-ci/bin/maas-run tags=virtual focal ga-20.04 default bin/test-lxd-network-ovn
 
     properties:
     - build-discarder:

--- a/jenkins/jobs/lxd-test-network-routed.yaml
+++ b/jenkins/jobs/lxd-test-network-routed.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/maas-run tags=physical jammy ga-22.04 default bin/test-lxd-network-routed
+        exec /lxc-ci/bin/maas-run tags=physical jammy ga-22.04 default bin/test-lxd-network-routed
 
     properties:
     - build-discarder:

--- a/jenkins/jobs/lxd-test-network-sriov.yaml
+++ b/jenkins/jobs/lxd-test-network-sriov.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/maas-run name=lantea jammy ga-22.04 iommu bin/test-lxd-network-sriov
+        exec /lxc-ci/bin/maas-run name=lantea jammy ga-22.04 iommu bin/test-lxd-network-sriov
 
     properties:
     - build-discarder:

--- a/jenkins/jobs/lxd-test-network.yaml
+++ b/jenkins/jobs/lxd-test-network.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/maas-run name=lantea jammy ga-22.04 iommu bin/test-lxd-network
+        exec /lxc-ci/bin/maas-run name=lantea jammy ga-22.04 iommu bin/test-lxd-network
 
     properties:
     - build-discarder:

--- a/jenkins/jobs/lxd-test-pylxd.yaml
+++ b/jenkins/jobs/lxd-test-pylxd.yaml
@@ -27,7 +27,7 @@
         track=$(echo ${target} | cut -d- -f1)
         channel=$(echo ${target} | cut -d- -f2)
 
-        exec sudo /lxc-ci/bin/maas-run tags=virtual jammy ga-22.04 cgroup1 bin/test-lxd-pylxd "${track}" "${channel}"
+        exec /lxc-ci/bin/maas-run tags=virtual jammy ga-22.04 cgroup1 bin/test-lxd-pylxd "${track}" "${channel}"
 
     properties:
     - build-discarder:

--- a/jenkins/jobs/lxd-test-rbac.yaml
+++ b/jenkins/jobs/lxd-test-rbac.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/maas-run tags=virtual jammy ga-22.04 default bin/test-lxd-rbac
+        exec /lxc-ci/bin/maas-run tags=virtual jammy ga-22.04 default bin/test-lxd-rbac
 
     properties:
     - build-discarder:

--- a/jenkins/jobs/lxd-test-snap-migration.yaml
+++ b/jenkins/jobs/lxd-test-snap-migration.yaml
@@ -37,17 +37,17 @@
         channel=$(echo ${target} | cut -d- -f2)
 
         if [ "${source}" = "xenial-updates" ]; then
-            exec sudo /lxc-ci/bin/maas-run tags=virtual xenial ga-16.04 default bin/test-lxd-migration "xenial-updates" "${track}" "${channel}"
+            exec /lxc-ci/bin/maas-run tags=virtual xenial ga-16.04 default bin/test-lxd-migration "xenial-updates" "${track}" "${channel}"
         elif [ "${source}" = "xenial-backports" ]; then
-            exec sudo /lxc-ci/bin/maas-run tags=virtual xenial ga-16.04 default bin/test-lxd-migration "xenial-backports" "${track}" "${channel}"
+            exec /lxc-ci/bin/maas-run tags=virtual xenial ga-16.04 default bin/test-lxd-migration "xenial-backports" "${track}" "${channel}"
         elif [ "${source}" = "bionic-updates" ]; then
-            exec sudo /lxc-ci/bin/maas-run tags=virtual bionic ga-18.04 default bin/test-lxd-migration "bionic-updates" "${track}" "${channel}"
+            exec /lxc-ci/bin/maas-run tags=virtual bionic ga-18.04 default bin/test-lxd-migration "bionic-updates" "${track}" "${channel}"
         elif [ "${source}" = "xenial-updates-hwe" ]; then
-            exec sudo /lxc-ci/bin/maas-run tags=virtual xenial hwe-16.04 default bin/test-lxd-migration "xenial-updates" "${track}" "${channel}"
+            exec /lxc-ci/bin/maas-run tags=virtual xenial hwe-16.04 default bin/test-lxd-migration "xenial-updates" "${track}" "${channel}"
         elif [ "${source}" = "xenial-backports-hwe" ]; then
-            exec sudo /lxc-ci/bin/maas-run tags=virtual xenial hwe-16.04 default bin/test-lxd-migration "xenial-backports" "${track}" "${channel}"
+            exec /lxc-ci/bin/maas-run tags=virtual xenial hwe-16.04 default bin/test-lxd-migration "xenial-backports" "${track}" "${channel}"
         elif [ "${source}" = "bionic-updates-hwe" ]; then
-            exec sudo /lxc-ci/bin/maas-run tags=virtual bionic hwe-18.04 default bin/test-lxd-migration "bionic-updates" "${track}" "${channel}"
+            exec /lxc-ci/bin/maas-run tags=virtual bionic hwe-18.04 default bin/test-lxd-migration "bionic-updates" "${track}" "${channel}"
         else
             exit 1
         fi

--- a/jenkins/jobs/lxd-test-storage-disks-vm.yaml
+++ b/jenkins/jobs/lxd-test-storage-disks-vm.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/maas-run tags=physical jammy ga-22.04 default bin/test-lxd-storage-disks-vm
+        exec /lxc-ci/bin/maas-run tags=physical jammy ga-22.04 default bin/test-lxd-storage-disks-vm
 
     properties:
     - build-discarder:

--- a/jenkins/jobs/lxd-test-usb.yaml
+++ b/jenkins/jobs/lxd-test-usb.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/maas-run name=lantea jammy ga-22.04 default bin/test-lxd-usb
+        exec /lxc-ci/bin/maas-run name=lantea jammy ga-22.04 default bin/test-lxd-usb
 
     properties:
     - build-discarder:


### PR DESCRIPTION
Not using sudo should make it easier to cancel jobs.