### PR TITLE
bin/test-lxd-kernel: Supply --yes to apt-get remove command

### DIFF
--- a/bin/test-lxd-kernel
+++ b/bin/test-lxd-kernel
@@ -30,7 +30,7 @@ apt-add-repository ppa:ubuntu-lxc/daily --yes
 apt-get dist-upgrade --yes
 
 apt-get install --no-install-recommends --yes libudev-dev liblxc-dev liblz4-dev libacl1-dev libuv1-dev libselinux-dev libseccomp-dev tcl libsqlite3-dev libcap-dev dh-autoreconf build-essential acl attr easy-rsa ebtables jq pkg-config socat sqlite3 dnsmasq-base dnsutils nftables gettext
-apt-get remove --purge uidmap cloud-init
+apt-get remove --purge --yes uidmap cloud-init
 rm -f /etc/subuid* /etc/subgid*
 snap remove lxd
 


### PR DESCRIPTION
The test was hanging on:

Package 'uidmap' is not installed, so not removed
The following packages will be REMOVED:
  cloud-init*
0 upgraded, 0 newly installed, 1 to remove and 2 not upgraded. After this operation, 2839 kB disk space will be freed. Do you want to continue? [Y/n] Abort.
==> Releasing the machine

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>