### PR TITLE
test-lxd-gpu-mig: Drop quotes around $UUIDS

### DIFF
--- a/bin/test-lxd-gpu-mig
+++ b/bin/test-lxd-gpu-mig
@@ -68,10 +68,14 @@ nvidia-smi mig -cci 1c.2g.10gb,1c.2g.10gb -gi 5
 nvidia-smi
 
 UUIDS="$(nvidia-smi -L | grep MIG- | sed -e "s/.*UUID: //g" -e "s/).*//g")"
-UUID1="$(echo "$UUIDS" | cut -d' ' -f1)"
-UUID2="$(echo "$UUIDS" | cut -d' ' -f2)"
-UUID3="$(echo "$UUIDS" | cut -d' ' -f3)"
-UUID4="$(echo "$UUIDS" | cut -d' ' -f4)"
+# shellcheck disable=SC2086
+UUID1="$(echo $UUIDS | cut -d' ' -f1)"
+# shellcheck disable=SC2086
+UUID2="$(echo $UUIDS | cut -d' ' -f2)"
+# shellcheck disable=SC2086
+UUID3="$(echo $UUIDS | cut -d' ' -f3)"
+# shellcheck disable=SC2086
+UUID4="$(echo $UUIDS | cut -d' ' -f4)"
 
 # Launch test containers
 lxc init images:ubuntu/20.04 nvidia-mig1 -c nvidia.runtime=true


### PR DESCRIPTION
This removes the quotes around $UUIDS as they lead to UUIDx each being
a list of UUIDs instead of a single one.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
