### PR TITLE
test-lxd-gpu-mig: simplify GPU UUID handling

### DIFF
--- a/bin/test-lxd-gpu-mig
+++ b/bin/test-lxd-gpu-mig
@@ -67,15 +67,11 @@ nvidia-smi mig -cci 1g.5gb -gi 13
 nvidia-smi mig -cci 1c.2g.10gb,1c.2g.10gb -gi 5
 nvidia-smi
 
-UUIDS="$(nvidia-smi -L | grep MIG- | sed -e "s/.*UUID: //g" -e "s/).*//g")"
-# shellcheck disable=SC2086
-UUID1="$(echo $UUIDS | cut -d' ' -f1)"
-# shellcheck disable=SC2086
-UUID2="$(echo $UUIDS | cut -d' ' -f2)"
-# shellcheck disable=SC2086
-UUID3="$(echo $UUIDS | cut -d' ' -f3)"
-# shellcheck disable=SC2086
-UUID4="$(echo $UUIDS | cut -d' ' -f4)"
+UUIDS="$(nvidia-smi -L | sed -n "/(UUID: MIG-/ s/.* \(MIG-[^)]\+\))$/\1/p")"
+UUID1="$(echo "$UUIDS" | sed -n '1p')"
+UUID2="$(echo "$UUIDS" | sed -n '2p')"
+UUID3="$(echo "$UUIDS" | sed -n '3p')"
+UUID4="$(echo "$UUIDS" | sed -n '4p')"
 
 # Launch test containers
 lxc init images:ubuntu/20.04 nvidia-mig1 -c nvidia.runtime=true


### PR DESCRIPTION
The `$UUIDS` var being a multiline list, use `sed` to print the desired line.