### PR TITLE
images/alpine: Mount /dev/shm in containers to fix Podman

### DIFF
--- a/images/alpine.yaml
+++ b/images/alpine.yaml
@@ -373,7 +373,7 @@ actions:
     sed -i 's/-lxc//' /etc/init.d/localmount
 
     # Enable services
-    for svc_name in bootmisc syslog; do
+    for svc_name in bootmisc syslog devfs; do
         ln -s /etc/init.d/${svc_name} /etc/runlevels/boot/${svc_name}
     done
 


### PR DESCRIPTION
The devfs service is still useful for mounting /dev/shm in containers. Without /dev/shm, Podman fails to start in Alpine LXD containers:

```
Error: failed to get new shm lock manager: failed to create 2048 locks in /libpod_lock: no such file or directory
```