### PR TITLE
Fix netplan removal race in network tests

### DIFF
--- a/bin/test-lxd-network-bridge-firewall
+++ b/bin/test-lxd-network-bridge-firewall
@@ -81,7 +81,7 @@ firewallTests() {
     fi
 
     # Disable DHCP client and SLAAC acceptance so we don't get automatic IPs added.
-    lxc exec c1 -- rm -f /etc/netplan/*
+    lxc exec c1 -- rm -fr /etc/netplan
     lxc exec c1 -- netplan apply
     lxc exec c1 -- sysctl net.ipv6.conf.eth0.accept_ra=0
 

--- a/bin/test-lxd-network-bridge-firewall
+++ b/bin/test-lxd-network-bridge-firewall
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -eu
+set -eux
 
 waitSnapdSeed() (
   set +x

--- a/bin/test-lxd-network-ovn
+++ b/bin/test-lxd-network-ovn
@@ -1156,7 +1156,7 @@ ovn_peering_tests() {
     # Now reconfigure ovn1's IP address inside the instance to an unknown IP and try pinging ovn2.
     # Check that the security policies prevent those ICMP packets from reaching ovn2 instance.
     # Disable DHCP client and SLAAC acceptance so we don't get automatic IPs added.
-    lxc exec ovn1 --project=ovn1 -- rm -f /etc/netplan/*
+    lxc exec ovn1 --project=ovn1 -- rm -fr /etc/netplan
     lxc exec ovn1 --project=ovn1 -- netplan apply
     lxc exec ovn1 --project=ovn1 -- systemctl mask systemd-networkd
     lxc exec ovn1 --project=ovn1 -- systemctl stop systemd-networkd

--- a/bin/test-lxd-network-routed
+++ b/bin/test-lxd-network-routed
@@ -73,7 +73,7 @@ lxc start v1
 sleep 1m
 
 # Configure NIC in VM manually.
-lxc exec v1 -- rm -f /etc/netplan/*
+lxc exec v1 -- rm -fr /etc/netplan
 lxc exec v1 -- netplan apply
 lxc exec v1 -- systemctl mask systemd-networkd
 lxc exec v1 -- systemctl stop systemd-networkd


### PR DESCRIPTION
These tests have run fine for a while now, but recently the `test-lxd-network-bridge-firewall` test has started failing.
I setup a VM on MAAS to match the environment where this test ran and sure enough it failed.
It seems that the MAAS VMs are running **REALLY** slowly (perhaps the host is heavily loaded) and this exposed an underlying race condition due to the erroneous way we were (not) removing the netplan files.