### PR TITLE
images/openeuler: Temporary disable aarch64 builds

### DIFF
--- a/jenkins/jobs/image-openeuler.yaml
+++ b/jenkins/jobs/image-openeuler.yaml
@@ -11,7 +11,7 @@
         type: slave
         values:
         - amd64
-        - arm64
+        # - arm64
 
     - axis:
         name: release


### PR DESCRIPTION
This temporarily disables the aarch64 builds, as the docker source
always seems to pull the amd64 images.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
