### PR TITLE
build_distro: Retry cleanup without ever failing

### DIFF
--- a/bin/build-distro
+++ b/bin/build-distro
@@ -19,7 +19,13 @@ TARGET=${1}
 shift
 
 cleanup() {
-    lxc delete --force "${CNAME}"
+    for _ in $(seq 5); do
+        if lxc delete --force "${CNAME}"; then
+            break
+        fi
+
+        sleep 1
+    done
 }
 
 trap cleanup EXIT HUP INT TERM


### PR DESCRIPTION
This changes the cleanup function in that it retries deleting the build
container without ever failing.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
