### PR TITLE
jenkins/jobs: Add dqlite benchmark job

### DIFF
--- a/bin/test-dqlite-benchmark
+++ b/bin/test-dqlite-benchmark
@@ -1,0 +1,77 @@
+#!/bin/sh
+set -eu
+
+export DEBIAN_FRONTEND=noninteractive
+DIR=$(pwd)
+DATA_DIR=$DIR/dqlite-benchmark
+DURATION_S=$1
+
+cleanup() {
+    set +e
+
+    pkill -9 dqlite
+    rm -rf "$DATA_DIR"
+    sudo apt remove dqlite-tools -y
+
+    if [ "${FAIL}" = "1" ]; then
+        echo ""
+        echo "Test failed"
+        exit 1
+    fi
+
+    exit 0
+}
+
+run_benchmark() {
+    # shellcheck disable=SC3043
+    local masterpid
+
+    echo "Benchmark start duration:${DURATION_S}s arguments:$*"
+
+    mkdir -p "$DATA_DIR"
+
+    dqlite-benchmark "$@" --db 127.0.0.1:9001 --duration "$DURATION_S" --driver --cluster 127.0.0.1:9001,127.0.0.1:9002,127.0.0.1:9003 \
+    --workload kvreadwrite --dir "$DATA_DIR" &
+    masterpid=$!
+    dqlite-benchmark "$@" --db 127.0.0.1:9002 --join 127.0.0.1:9001 --dir "$DATA_DIR" &
+    dqlite-benchmark "$@" --db 127.0.0.1:9003 --join 127.0.0.1:9001 --dir "$DATA_DIR" &
+    wait $masterpid
+
+    echo "Write results:"
+    head -n 5 "$DATA_DIR"/127.0.0.1:9001/results/0-exec-*
+
+    echo ""
+    echo "Read results:"
+    head -n 5 "$DATA_DIR"/127.0.0.1:9001/results/0-query-*
+
+    tar -czf "dqlite-benchmark$*".tar.gz --directory="$DATA_DIR"/127.0.0.1:9001 results/
+    pkill -9 dqlite
+    rm -rf "$DATA_DIR"
+
+    echo "Benchmark completed"
+}
+
+FAIL=1
+trap cleanup EXIT HUP INT TERM
+
+# Make sure we're up to date
+while :; do
+    sudo add-apt-repository ppa:dqlite/dev -y && break
+    sudo apt-get update && break
+    sleep 10
+done
+
+while :; do
+    sudo apt-get dist-upgrade --yes && break
+    sleep 10
+done
+
+# Setup dependencies
+sudo apt-get install -y dqlite-tools
+
+# Run the tests
+run_benchmark
+sleep 2
+run_benchmark --disk
+
+FAIL=0

--- a/jenkins/jobs/dqlite-test-benchmark.yaml
+++ b/jenkins/jobs/dqlite-test-benchmark.yaml
@@ -1,0 +1,37 @@
+- job:
+    name: "dqlite-test-benchmark"
+    concurrent: false
+    description: Benchmarks dqlite's memory and disk-mode on a 3-node (local) cluster
+    node: master
+    project-type: freestyle
+
+    builders:
+    - shell: |-
+        cd /lxc-ci
+        exec /lxc-ci/bin/maas-run name=lantea jammy ga-22.04 default bin/test-dqlite-benchmark 2700
+
+    properties:
+    - build-discarder:
+        num-to-keep: 3
+
+    - raw:
+        !include: ../includes/webhook.yaml.inc
+
+    publishers:
+    - archive:
+        artifacts: dqlite-benchmark.tar.gz,dqlite-benchmark--disk.tar.gz
+        only-if-success: true
+
+    - naginator:
+        rerun-unstable-builds: true
+        rerun-matrix-part: true
+        max-failed-builds: 3
+        progressive-delay-increment: 300
+        progressive-delay-maximum: 900
+
+    triggers:
+    - timed: '@daily'
+
+    wrappers:
+    - ansicolor:
+        colormap: css


### PR DESCRIPTION
This will run the dqlite-benchmark tool on a 3-node cluster on lantea. Once for vanilla dqlite and once for disk-mode.
Both runs take 45 mins (1.5h total) and will approximately use 50GB of disk space (rough estimate).

@stgraber Should I make the `DATA_DIR` on a special drive, or is the location I've chosen fine?

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>