### PR TITLE
ci: update `differential-shellcheck` to `@v4`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@v3
+      - id: ShellCheck
+        name: Differential ShellCheck
+        uses: redhat-plumbers-in-action/differential-shellcheck@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: ${{ always() }}
+        name: Upload artifact with ShellCheck defects in SARIF format
+        uses: actions/upload-artifact@v3
+        with:
+          name: Differential ShellCheck SARIF
+          path: ${{ steps.ShellCheck.outputs.sarif }}


### PR DESCRIPTION
release notes for [`differential-shellcheck@v4`](https://github.com/redhat-plumbers-in-action/differential-shellcheck/releases/tag/v4.0.0) - [CHANGELOG](https://github.com/redhat-plumbers-in-action/differential-shellcheck/blob/main/docs/CHANGELOG.md#v400)