### PR TITLE
jenkins/jobs: Disable Funtoo/next on armhf

### DIFF
--- a/jenkins/jobs/image-funtoo.yaml
+++ b/jenkins/jobs/image-funtoo.yaml
@@ -41,6 +41,10 @@
             ${LXD_ARCHITECTURE} container 7200 ${WORKSPACE} \
             -o image.release=${release} -o image.architecture=${ARCH}
 
+    execution-strategy:
+      combination-filter: '
+      !(architecture=="armhf" && release == "next")'
+
     properties:
     - build-discarder:
         num-to-keep: 2


### PR DESCRIPTION
This disables Funtoo/next on armhf as there is no tarball available for
this.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
