### PR TITLE
ci: Add missing permission `security-events`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,9 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    
+    permissions:
+      security-events: write
 
     steps:
       - name: Repository checkout


### PR DESCRIPTION
Differential ShellCheck requires permission `security-events: write` to upload the SARIF file to GitHub successfully.

This permission might be optional for some repositories since they allow all permissions for all workflows in settings. But I wouldn't advise this setting since the best security practice is to allow only a minimal set of required permissions.

Failing SARIF upload - [logs](https://github.com/lxc/lxc-ci/actions/runs/3998352029/jobs/6860885436#step:4:31)