### PR TITLE
images/fedora: Fix Rawhide GPG key

### DIFF
--- a/images/fedora.yaml
+++ b/images/fedora.yaml
@@ -234,11 +234,20 @@ actions:
     # Let dnf find the fastest mirror
     echo fastestmirror=True >> /etc/dnf/dnf.conf
 
+    # Backup all repo files
+    for repo in $(ls /etc/yum.repos.d/*.repo); do
+      cp "${repo}" "${repo}.bak"
+    done
+
+- trigger: post-unpack
+  action: |-
+    #!/bin/sh
+
+    set -eux
+
     # Use baseurl instead of metalink to avoid networking issues
     for repo in $(ls /etc/yum.repos.d/*.repo); do
       grep -q '^#baseurl' "${repo}" || continue
-
-      cp "${repo}" "${repo}.bak"
 
       sed -ri 's/^metalink=.*/#\0/g;s@^#(baseurl=)http://download.example/pub(.*)@\1https://mirror.csclub.uwaterloo.ca/\2@g' "${repo}"
     done
@@ -253,17 +262,27 @@ actions:
 
     set -eux
 
-    # Increase connection timeout
-    echo timeout=60 >> /etc/dnf/dnf.conf
+    # Use Fedora 38 GPG key to avoid package installation errors
+    for repo in $(ls /etc/yum.repos.d/*.repo); do
+      grep -q 'RPM-GPG-KEY-fedora-38' "${repo}" && continue
 
-    # Let dnf find the fastest mirror
-    echo fastestmirror=True >> /etc/dnf/dnf.conf
+      sed -ri 's#^gpgkey=.*#\0 file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-38-$basearch#g' "${repo}"
+    done
+  architectures:
+  - aarch64
+  - x86_64
+  releases:
+  - Rawhide
+
+- trigger: post-unpack
+  action: |-
+    #!/bin/sh
+
+    set -eux
 
     # Use baseurl instead of metalink to avoid networking issues
     for repo in $(ls /etc/yum.repos.d/*.repo); do
       grep -q '^#baseurl' "${repo}" || continue
-
-      cp "${repo}" "${repo}.bak"
 
       sed -ri 's/^metalink=.*/#\0/g;s@^#(baseurl=)http://download.example/pub/fedora/linux(.*)@\1https://muug.ca/mirror/fedora-secondary\2@g' "${repo}"
     done


### PR DESCRIPTION
This uses the Fedora 38 GPG key for Rawhide packages.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
