### PR TITLE
lxc-github-commit/pull: test both epoll and io_uring async API

### DIFF
--- a/bin/build-image-lxc
+++ b/bin/build-image-lxc
@@ -56,7 +56,7 @@ apt-get install --yes --no-install-recommends \
     libseccomp-dev libselinux1-dev libssl-dev libtool linux-libc-dev \
     lsb-release make openssl pkg-config python3-all-dev \
     python3-setuptools rsync squashfs-tools uidmap unzip uuid-runtime \
-    wget xz-utils
+    wget xz-utils liburing-dev
 
 apt-get clean
 

--- a/bin/testbuild-clang
+++ b/bin/testbuild-clang
@@ -2,12 +2,14 @@
 CNAME="lxc-test-$(uuidgen)"
 
 # Check arguments
-if [ "${1:-}" = "" ] || [ "${2:-}" = "" ] || [ "${3:-}" = "" ] || [ "${4:-}" = "" ]; then
-    echo "Usage: ${0} <arch> <repository> <branch> <commit>"
+if [ "${1:-}" = "" ] || [ "${2:-}" = "" ] || [ "${3:-}" = "" ] || [ "${4:-}" = "" ] || [ "${5:-}" = "" ]; then
+    echo "Usage: ${0} <arch> <async-api> <repository> <branch> <commit>"
     exit 1
 fi
 
 ARCH=${1}
+shift
+ASYNC_API=${1}
 shift
 REPO=${1}
 shift
@@ -67,7 +69,11 @@ if [ -e autogen.sh ]; then
     make
     make install
 else
-    CC=clang CC_LD=gold meson setup build/ -Dtests=true -Dpam-cgroup=true -Dprefix=/usr/ -Dsysconfdir=/etc/ -Dlocalstatedir=/var/
+    WANT_IO_URING="-Dio-uring-event-loop=false"
+    if [ "${ASYNC_API}" = "io_uring" ]; then
+        WANT_IO_URING="-Dio-uring-event-loop=true"
+    fi
+    CC=clang CC_LD=gold meson setup build/ "${WANT_IO_URING}" -Dtests=true -Dpam-cgroup=true -Dprefix=/usr/ -Dsysconfdir=/etc/ -Dlocalstatedir=/var/
     ninja -C build
     ninja -C build install
 fi

--- a/bin/testbuild-gcc
+++ b/bin/testbuild-gcc
@@ -2,12 +2,14 @@
 CNAME="lxc-test-$(uuidgen)"
 
 # Check arguments
-if [ "${1:-}" = "" ] || [ "${2:-}" = "" ] || [ "${3:-}" = "" ] || [ "${4:-}" = "" ]; then
-    echo "Usage: ${0} <arch> <repository> <branch> <commit>"
+if [ "${1:-}" = "" ] || [ "${2:-}" = "" ] || [ "${3:-}" = "" ] || [ "${4:-}" = "" ] || [ "${5:-}" = "" ]; then
+    echo "Usage: ${0} <arch> <async-api> <repository> <branch> <commit>"
     exit 1
 fi
 
 ARCH=${1}
+shift
+ASYNC_API=${1}
 shift
 REPO=${1}
 shift
@@ -67,7 +69,11 @@ if [ -e autogen.sh ]; then
     make
     make install
 else
-    meson setup build/ -Dtests=true -Dpam-cgroup=true -Dprefix=/usr/ -Dsysconfdir=/etc/ -Dlocalstatedir=/var/
+    WANT_IO_URING="-Dio-uring-event-loop=false"
+    if [ "${ASYNC_API}" = "io_uring" ]; then
+        WANT_IO_URING="-Dio-uring-event-loop=true"
+    fi
+    meson setup build/ "${WANT_IO_URING}" -Dtests=true -Dpam-cgroup=true -Dprefix=/usr/ -Dsysconfdir=/etc/ -Dlocalstatedir=/var/
     ninja -C build
     ninja -C build install
 fi

--- a/jenkins/jobs/lxc-github-commit.yaml
+++ b/jenkins/jobs/lxc-github-commit.yaml
@@ -37,6 +37,13 @@
         - clang
 
     - axis:
+        name: async-api
+        type: user-defined
+        values:
+        - epoll
+        - io_uring
+
+    - axis:
         name: arch
         type: slave
         values:
@@ -52,7 +59,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/testbuild-${{compiler}} ${{arch}} https://github.com/lxc/lxc {branch} ${{GIT_COMMIT}}
+        exec sudo /lxc-ci/bin/testbuild-${{compiler}} ${{arch}} ${async-api} https://github.com/lxc/lxc {branch} ${{GIT_COMMIT}}
 
     properties:
     - build-discarder:

--- a/jenkins/jobs/lxc-github-pull-test.yaml
+++ b/jenkins/jobs/lxc-github-pull-test.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec sudo /lxc-ci/bin/testbuild-${compiler} ${arch} https://github.com/lxc/lxc master ${GIT_COMMIT}
+        exec sudo /lxc-ci/bin/testbuild-${compiler} ${arch} ${async-api} https://github.com/lxc/lxc master ${GIT_COMMIT}
 
     - trigger-builds:
       - project:
@@ -60,6 +60,13 @@
         values:
         - gcc
         - clang
+
+    - axis:
+        name: async-api
+        type: user-defined
+        values:
+        - epoll
+        - io_uring
 
     - axis:
         name: arch


### PR DESCRIPTION
As we can see from test logs:
https://jenkins.linuxcontainers.org/job/lxc-github-pull-test/4741/arch=amd64,compiler=gcc,restrict=vm/consoleFull Message: lxc 5.0.0
...
     time epoch:			1655407214 (2022-06-16T19:20:14+00:00)

     supported dependencies:	AppArmor, SECCOMP, SELinux, libcap, static libcap, pam, openssl

     unsupported dependencies:	liburing, libsystemd

We don't test LXC with io_uring async API.