### PR TITLE
vmgenid: check that vmgenid (in qemu.conf) is different than `volatile.uuid.generation`

### DIFF
--- a/bin/test-lxd-storage-vm
+++ b/bin/test-lxd-storage-vm
@@ -430,8 +430,7 @@ do
 
         # Check that the volatile.uuid.generation setting is applied to the QEMU process.
         vmGenID=$(lxc config get v1 volatile.uuid.generation)
-        vmPID=$(lxc info v1 | awk '/^PID:/ {print $2}')
-        qemuGenID=$(sed -n 's/.*vmgenid,guid=\([0-9a-fA-F]\{8\}-[0-9a-fA-F]\{4\}-[0-9a-fA-F]\{4\}-[0-9a-fA-F]\{4\}-[0-9a-fA-F]\{12\}\).*/\1/p' "/proc/${vmPID}/cmdline")
+        qemuGenID=$(awk '/driver = "vmgenid"/,/guid = / {print $3}' /var/snap/lxd/common/lxd/logs/v1/qemu.conf | sed -n 's/"\([0-9a-fA-F]\{8\}-[0-9a-fA-F]\{4\}-[0-9a-fA-F]\{4\}-[0-9a-fA-F]\{4\}-[0-9a-fA-F]\{12\}\)"/\1/p')
         if [ "${vmGenID}" != "${qemuGenID}" ]; then
                 echo "==> VM Generation ID in LXD config does not match VM Generation ID in QEMU process"
                 false


### PR DESCRIPTION
* Test associated with https://github.com/lxc/lxd/pull/11498

TEST : 

* side loading (see here https://paste.ubuntu.com/p/6H7fW2kM9p/) and manual testing OK