### PR TITLE
Drop Go 1.17

### DIFF
--- a/bin/build-cache
+++ b/bin/build-cache
@@ -54,7 +54,6 @@ apt-get clean
 # Setup snapd
 snap set system experimental.parallel-instances=true
 snap install go_113 --channel=1.13 --unaliased --classic
-snap install go_117 --channel=1.17 --unaliased --classic
 snap install go_118 --channel=1.18 --unaliased --classic
 snap install go_tip --channel=latest/edge --unaliased --classic
 

--- a/bin/build-cache-lxd
+++ b/bin/build-cache-lxd
@@ -110,7 +110,7 @@ elif [ "${arch}" = "arm64" ]; then
 fi
 
 OLD_PATH=${PATH}
-for version in 1.13 1.17 1.18 tip; do
+for version in 1.13 1.18 tip; do
     VER=$(echo $version | sed "s/\.//g")
     export PATH="/snap/go_${VER}/current/bin:${OLD_PATH}"
 


### PR DESCRIPTION
Version 1.17 is EOL and doesn't match the version shipped in
Ubuntu LTS releases (Focal ships 1.13 and Jammy 1.18).