### PR TITLE
build-image-lxc: add dbus-1 build dependency

### DIFF
--- a/bin/build-image-lxc
+++ b/bin/build-image-lxc
@@ -56,7 +56,7 @@ apt-get install --yes --no-install-recommends \
     libseccomp-dev libselinux1-dev libssl-dev libtool linux-libc-dev \
     lsb-release make openssl pkg-config python3-all-dev \
     python3-setuptools rsync squashfs-tools uidmap unzip uuid-runtime \
-    wget xz-utils liburing-dev
+    wget xz-utils liburing-dev libdbus-1-dev
 
 apt-get clean
 


### PR DESCRIPTION
Since https://github.com/lxc/lxc/commit/820d2a2b3a886ebfe46cd256ba8c320e50fcc5cd LXC commit there is a new build dependency libdbus-1-dev. So, let's install it to fix CI tests.

Failure example:
https://jenkins.linuxcontainers.org/job/lxc-github-pull-test/4769/arch=amd64,async=epoll,compiler=gcc,restrict=vm/consoleText

Related LXC PR:
https://github.com/lxc/lxc/pull/4287