### PR TITLE
bin/test-lxd-network-ovn: Don't race dynamic port IP allocation

### DIFF
--- a/bin/test-lxd-network-ovn
+++ b/bin/test-lxd-network-ovn
@@ -1426,8 +1426,8 @@ ovn_nested_vlan_tests() {
         network=ovn1 \
         nested=eth0 \
         vlan=1 \
-        ipv4.address=10.10.11.2 \
-        ipv6.address=fd42:4242:4242:1011::2
+        ipv4.address=10.10.11.10 \
+        ipv6.address=fd42:4242:4242:1011::10
 
     eth1MAC="$(lxc config get u1 volatile.eth1.hwaddr)"
 
@@ -1435,8 +1435,8 @@ ovn_nested_vlan_tests() {
         network=ovn1 \
         nested=eth0 \
         vlan=2 \
-        ipv4.address=10.10.11.3 \
-        ipv6.address=fd42:4242:4242:1011::3
+        ipv4.address=10.10.11.11 \
+        ipv6.address=fd42:4242:4242:1011::11
 
     eth2MAC="$(lxc config get u1 volatile.eth2.hwaddr)"
 
@@ -1447,8 +1447,8 @@ ovn_nested_vlan_tests() {
     lxc exec u1 -- ip netns add vlan_nesting1
     lxc exec u1 -- ip link set eth0.1 netns vlan_nesting1
     lxc exec u1 -- ip netns exec vlan_nesting1 ip link set lo up
-    lxc exec u1 -- ip netns exec vlan_nesting1 ip address add 10.10.11.2/24 dev eth0.1
-    lxc exec u1 -- ip netns exec vlan_nesting1 ip address add fd42:4242:4242:1011::2/64 dev eth0.1 nodad
+    lxc exec u1 -- ip netns exec vlan_nesting1 ip address add 10.10.11.10/24 dev eth0.1
+    lxc exec u1 -- ip netns exec vlan_nesting1 ip address add fd42:4242:4242:1011::10/64 dev eth0.1 nodad
     lxc exec u1 -- ip netns exec vlan_nesting1 ip link set eth0.1 up
 
     # Configure nested VLAN 2 inside u1 in a network namespace.
@@ -1456,8 +1456,8 @@ ovn_nested_vlan_tests() {
     lxc exec u1 -- ip netns add vlan_nesting2
     lxc exec u1 -- ip link set eth0.2 netns vlan_nesting2
     lxc exec u1 -- ip netns exec vlan_nesting2 ip link set lo up
-    lxc exec u1 -- ip netns exec vlan_nesting2 ip address add 10.10.11.3/24 dev eth0.2
-    lxc exec u1 -- ip netns exec vlan_nesting2 ip address add fd42:4242:4242:1011::3/64 dev eth0.2 nodad
+    lxc exec u1 -- ip netns exec vlan_nesting2 ip address add 10.10.11.11/24 dev eth0.2
+    lxc exec u1 -- ip netns exec vlan_nesting2 ip address add fd42:4242:4242:1011::11/64 dev eth0.2 nodad
     lxc exec u1 -- ip netns exec vlan_nesting2 ip link set eth0.2 up
 
     sleep 5
@@ -1466,20 +1466,20 @@ ovn_nested_vlan_tests() {
     lxc exec u1 -- ip netns exec vlan_nesting2 ip address
 
     # Check nested VLAN NICs are pingable from parent instance.
-    lxc exec u1 -- ping -c1 -4 -w5 10.10.11.2
-    lxc exec u1 -- ping -c1 -6 -w5 fd42:4242:4242:1011::2
-    lxc exec u1 -- ping -c1 -4 -w5 10.10.11.3
-    lxc exec u1 -- ping -c1 -6 -w5 fd42:4242:4242:1011::3
+    lxc exec u1 -- ping -c1 -4 -w5 10.10.11.10
+    lxc exec u1 -- ping -c1 -6 -w5 fd42:4242:4242:1011::10
+    lxc exec u1 -- ping -c1 -4 -w5 10.10.11.11
+    lxc exec u1 -- ping -c1 -6 -w5 fd42:4242:4242:1011::11
 
     # Check nested VLAN 2 NIC is pingable from VLAN 1 namespace.
-    lxc exec u1 -- ip netns exec vlan_nesting1 ping -c1 -4 -w5 10.10.11.3
-    lxc exec u1 -- ip netns exec vlan_nesting1 ping -c1 -6 -w5 fd42:4242:4242:1011::3
+    lxc exec u1 -- ip netns exec vlan_nesting1 ping -c1 -4 -w5 10.10.11.11
+    lxc exec u1 -- ip netns exec vlan_nesting1 ping -c1 -6 -w5 fd42:4242:4242:1011::11
 
     # Check nested VLAN NICs are pingable from a different instance on the same network.
-    lxc exec u2 -- ping -c1 -4 -w5 10.10.11.2
-    lxc exec u2 -- ping -c1 -6 -w5 fd42:4242:4242:1011::2
-    lxc exec u2 -- ping -c1 -4 -w5 10.10.11.3
-    lxc exec u2 -- ping -c1 -6 -w5 fd42:4242:4242:1011::3
+    lxc exec u2 -- ping -c1 -4 -w5 10.10.11.10
+    lxc exec u2 -- ping -c1 -6 -w5 fd42:4242:4242:1011::10
+    lxc exec u2 -- ping -c1 -4 -w5 10.10.11.11
+    lxc exec u2 -- ping -c1 -6 -w5 fd42:4242:4242:1011::11
 
     lxc delete -f u1 u2
     lxc network delete ovn1


### PR DESCRIPTION
By hotplugging statically assigned nested NICs during the instance start up we were getting IP conflicts where the instance's parent NIC had already been assigned (and configured) the statically assigned IP for the nested NIC.