### PR TITLE
fix openeuler build failed

### DIFF
--- a/jenkins/jobs/image-openeuler.yaml
+++ b/jenkins/jobs/image-openeuler.yaml
@@ -45,7 +45,7 @@
         exec sudo /lxc-ci/bin/build-distro /lxc-ci/images/openeuler.yaml \
             ${LXD_ARCHITECTURE} ${TYPE} 7200 ${WORKSPACE} \
             -o image.architecture=${ARCH} -o image.release=${release} \
-            -o image.variant=${variant} -o source.url="openeuler/openeuler:${release}" ${EXTRA_ARGS}
+            -o image.variant=${variant} ${EXTRA_ARGS}
 
     properties:
     - build-discarder:


### PR DESCRIPTION
To fix the failed [builds](https://jenkins.linuxcontainers.org/job/image-openeuler/architecture=amd64,release=22.09,variant=cloud/398/console), remove the ` -o source.url="openeuler/openeuler:${release}` which specified only for docker downloader.
For the record, the logs:
```
+ distrobuilder --cache-dir /root/build/cache/ --timeout 7200 build-dir image.yaml rootfs -o image.serial=20230422_16:28 -o image.architecture=x86_64 -o image.release=22.09 -o image.variant=cloud -o source.url=openeuler/openeuler:22.09
time="2023-04-22T16:28:38Z" level=info msg="Downloading source"
Error: Error while downloading source: Failed to get latest release by 22.09: Failed to read url: Get "openeuler/openeuler:22.09": unsupported protocol scheme ""
```