### PR TITLE
jenkins/jobs: Drop Devuan ASCII

### DIFF
--- a/jenkins/jobs/image-devuan.yaml
+++ b/jenkins/jobs/image-devuan.yaml
@@ -21,7 +21,6 @@
         name: release
         type: user-defined
         values:
-        - ascii
         - beowulf
         - chimaera
 


### PR DESCRIPTION
Devuan ASCII release has disappeared from the official server.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
