### PR TITLE
Drop Alpine Linux 3.14 (EOL) and add Alpine Linux 3.18

### DIFF
--- a/images/alpine.yaml
+++ b/images/alpine.yaml
@@ -309,22 +309,8 @@ packages:
   - packages:
     - alpine-base
     - logrotate
-    action: install
-
-  - packages:
-    - sudo
-    action: install
-    releases:
-    - 3.14
-
-  - packages:
     - doas
     action: install
-    releases:
-    - 3.15
-    - 3.16
-    - 3.17
-    - edge
 
   - packages:
     - cloud-init

--- a/images/alpine.yaml
+++ b/images/alpine.yaml
@@ -327,6 +327,7 @@ packages:
     - cloud
     releases:
     - 3.17
+    - 3.18
     - edge
 
   - packages:

--- a/jenkins/jobs/image-alpine.yaml
+++ b/jenkins/jobs/image-alpine.yaml
@@ -21,7 +21,6 @@
         name: release
         type: user-defined
         values:
-        - "3.14"
         - "3.15"
         - "3.16"
         - "3.17"

--- a/jenkins/jobs/image-alpine.yaml
+++ b/jenkins/jobs/image-alpine.yaml
@@ -24,6 +24,7 @@
         - "3.15"
         - "3.16"
         - "3.17"
+        - "3.18"
         - "edge"
 
     - axis:
@@ -50,7 +51,7 @@
 
         EXTRA_ARGS=""
         if [ "${release}" = "edge" ]; then
-            EXTRA_ARGS="-o source.same_as=3.16"
+            EXTRA_ARGS="-o source.same_as=3.18"
         fi
 
         exec sudo /lxc-ci/bin/build-distro /lxc-ci/images/alpine.yaml \


### PR DESCRIPTION
- images: Drop Alpine Linux 3.14 (EOL)
- images: Add Alpine Linux 3.18
