### PR TITLE
images/debian: Fix networkd in bookworm containers

### DIFF
--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -1198,6 +1198,7 @@ actions:
   - default
   releases:
   - bullseye
+  - bookworm
 
 - trigger: post-packages
   action: |-
@@ -1209,7 +1210,6 @@ actions:
   types:
   - container
   releases:
-  - bookworm
   - sid
 
 - trigger: post-packages


### PR DESCRIPTION
Default Debian bookworm container images boot with the eth0 interface down, so networking does not work. Starting `systemd-networkd` manually fixes the network.