### PR TITLE
Add Plamo Linux 8.x

### DIFF
--- a/images/plamo.yaml
+++ b/images/plamo.yaml
@@ -50,85 +50,6 @@ files:
 - name: inittab
   path: /etc/inittab
   generator: dump
-  releases:
-  - 6.x
-  content: |-
-    #
-    # inittab	This file describes how the INIT process should set up
-    #		the system in a certain run-level.
-    #
-    # Version:	@(#)inittab		2.04	17/05/93	MvS
-    #                                       2.10    02/10/95        PV
-    #
-    # Author:	Miquel van Smoorenburg, <miquels@drinkel.nl.mugnet.org>
-    # Modified by:	Patrick J. Volkerding, <volkerdi@ftp.cdrom.com>
-    #
-    # Default runlevel.
-    id:3:initdefault:
-
-    # System initialization (runs when system boots).
-    si:S:sysinit:/etc/rc.d/rc.S
-
-    # Script to run when going single user (runlevel 1).
-    su:1S:wait:/etc/rc.d/rc.K
-
-    # Script to run when going multi user.
-    rc:2345:wait:/etc/rc.d/rc.M
-
-    # What to do at the "Three Finger Salute".
-    ca::ctrlaltdel:/sbin/shutdown -t5 -rf now
-
-    # Runlevel 0 halts the system.
-    l0:0:wait:/etc/rc.d/rc.0
-
-    # Runlevel 6 reboots the system.
-    l6:6:wait:/etc/rc.d/rc.6
-
-    # What to do when power fails (shutdown).
-    pf::powerfail:/sbin/shutdown -h +0 "THE POWER IS FAILING"
-
-    # If power is back before shutdown, cancel the running shutdown.
-    pg:0123456:powerokwait:/sbin/shutdown -c "THE POWER IS BACK"
-
-    # If power comes back in single user mode, return to multi user mode.
-    ps:S:powerokwait:/sbin/init 5
-
-    # The getties in multi user mode on consoles an serial lines.
-    #
-    # NOTE NOTE NOTE adjust this to your getty or you will not be
-    #                able to login !!
-    #
-    # Note: for 'agetty' you use linespeed, line.
-    # for 'getty_ps' you use line, linespeed and also use 'gettydefs'
-    1:1235:respawn:/sbin/agetty 38400 console
-    c1:1235:respawn:/sbin/agetty 38400 tty1 linux
-    c2:1235:respawn:/sbin/agetty 38400 tty2 linux
-    c3:1235:respawn:/sbin/agetty 38400 tty3 linux
-    c4:1235:respawn:/sbin/agetty 38400 tty4 linux
-
-    # Serial lines
-    #s1:12345:respawn:/sbin/agetty 19200 ttyS0 vt100
-    #s2:12345:respawn:/sbin/agetty 19200 ttyS1 vt100
-
-    # Dialup lines
-    #d1:12345:respawn:/sbin/agetty -mt60 38400,19200,9600,2400,1200 ttyS0 vt100
-    #d2:12345:respawn:/sbin/agetty -mt60 38400,19200,9600,2400,1200 ttyS1 vt100
-
-    # Runlevel 4 used to be for an X-window only system, until we discovered
-    # that it throws init into a loop that keeps your load avg at least 1 all
-    # the time. Thus, there is now one getty opened on tty6. Hopefully no one
-    # will notice. ;^)
-    # It might not be bad to have one text console anyway, in case something
-    # happens to X.
-    x1:4:wait:/etc/rc.d/rc.4
-
-    # End of /etc/inittab
-
-- name: inittab
-  path: /etc/inittab
-  generator: dump
-  releases:
-  - 7.x
   content: |-
     # /etc/inittab derived from LFS 20170713
     # Begin /etc/inittab
@@ -160,22 +81,6 @@ files:
 - name: fstab
   path: /etc/fstab
   generator: dump
-  releases:
-  - 6.x
-  content: |-
-    none            /proc                   proc        defaults        0 0
-    none            /sys                    sysfs       defaults        0 0
-    none            /dev                    tmpfs       defaults        0 0
-    none            /tmp                    tmpfs       defaults        0 0
-    none            /dev/pts                devpts      gid=5,mode=620  0 0
-    none            /proc/bus/usb           usbfs       noauto          0 0
-    none            /var/lib/nfs/rpc_pipefs rpc_pipefs  defaults        0 0
-
-- name: fstab
-  path: /etc/fstab
-  generator: dump
-  releases:
-  - 7.x
   content: |-
     proc            /proc           proc    defaults        0 0
     tmpfs           /run            tmpfs   defaults        0 0
@@ -185,18 +90,8 @@ files:
     usbfs           /proc/bus/usb   usbfs   noauto          0 0
 
 - name: eth0
-  path: /var/run/inet1-scheme
-  generator: dump
-  releases:
-  - 6.x
-  content: |-
-    DHCP
-
-- name: eth0
   path: /etc/sysconfig/ifconfig.eth0
   generator: dump
-  releases:
-  - 7.x
   content: |-
     ONBOOT="yes"
     IFACE="eth0"
@@ -232,73 +127,6 @@ actions:
     sed -i '/pam_loginuid/s/^/#/' /etc/pam.d/login
 
 - trigger: post-unpack
-  releases:
-  - 6.x
-  action: |
-    #!/bin/sh
-    set -eux
-
-    # Suppress log level output for udev
-    sed -i 's/="err"/=0/' /etc/udev/udev.conf
-
-    # Configure glibc
-    [ -f /etc/ld.so.conf.new ] && mv /etc/ld.so.conf.new /etc/ld.so.conf
-    ldconfig
-
-    # Delete unnecessary process from rc.S
-    ed - /etc/rc.d/rc.S << EOF
-      /^mount -w -n -t proc/;/^mkdir \/dev\/shm/-1d
-      /^mknod \/dev\/null/;/^# Clean \/etc\/mtab/-2d
-      /^# copy the rules/;/^# Set the hostname/-1d
-      /^# Check the integrity/;/^# Clean up temporary/-1d
-      w
-    EOF
-
-    # Delete unnecessary process from rc.M
-    ed - /etc/rc.d/rc.M << EOF
-      /^# Screen blanks/;/^# Initialize ip6tables/-1d
-      /^# Initialize sysctl/;/^echo "Starting services/-1d
-      /^sync/;/^# All done/-1d
-      w
-    EOF
-
-    # Delete unnecessary process from rc.6
-    ed - /etc/rc.d/rc.6 << EOF
-      /^# Save system time/;/^# Unmount any remote filesystems/-1d
-      /^# Turn off swap/;/^# See if this is a powerfail situation/-1d
-      w
-    EOF
-
-    # Networking
-    head -n-93 /sbin/netconfig.tradnet > /tmp/netconfig.rconly
-    cat << EOF >> /tmp/netconfig.rconly
-    	PCMCIA=n
-    	RC=/etc/rc.d/rc.inet1.tradnet
-    	IFCONFIG=sbin/ifconfig
-    	ROUTE=sbin/route
-    	INET1SCHEME=var/run/inet1-scheme
-    	IPADDR=127.0.0.1
-    	NETWORK=127.0.0.0
-    	DHCPCD=usr/sbin/dhclient
-    	LOOPBACK=y
-    	make_config_file
-    EOF
-
-    rm -f /etc/rc.d/rc.inet1.tradnet
-    sh /tmp/netconfig.rconly
-    rm -f /tmp/netconfig.rconly
-    sed -i '/cmdline/s/if/& false \&\&/' /etc/rc.d/rc.inet1.tradnet
-
-    # /etc/rc.d/rc.inet2
-    sed -i "/rpc.mountd/s/^/#/" /etc/rc.d/rc.inet2
-    sed -i "/modprobe/s/^/#/" /etc/rc.d/rc.inet2
-
-    # Disable services
-    rm -f /var/log/initpkg/shadow
-
-- trigger: post-unpack
-  releases:
-  - 7.x
   action: |
     #!/bin/sh
     set -eux

--- a/jenkins/jobs/image-plamo.yaml
+++ b/jenkins/jobs/image-plamo.yaml
@@ -16,8 +16,8 @@
         name: release
         type: user-defined
         values:
-        - 6.x
         - 7.x
+        - 8.x
 
     - axis:
         name: variant


### PR DESCRIPTION
Plamo Linux 8.0 has been released and now supports the 8.x series of images. And we do not support the 6.x series anymore and there are no package updates, so we remove them from the build target.

* Removed configurations for 6.x.
* The "releases" specifying "7.x" have been removed, as there is no difference in the processing required for 7.x and 8.x.