### PR TITLE
Revert "test-lxd-network-ovn: Fix dnsmasq unmask issue due to upstream changes"

### DIFF
--- a/bin/test-lxd-network-ovn
+++ b/bin/test-lxd-network-ovn
@@ -744,7 +744,6 @@ bind-interfaces
 interface-name=u1.lxd,eth0
 EOF
 
-    lxc exec u1 -- rm /run/systemd/system/dnsmasq.service
     lxc exec u1 -- systemctl unmask dnsmasq
     lxc exec u1 -- systemctl start dnsmasq
     dig a +tcp @192.0.2.1 u1.lxd
@@ -770,7 +769,6 @@ bind-interfaces
 interface-name=u2.lxd,eth0
 EOF
 
-    lxc exec u2 -- rm /run/systemd/system/dnsmasq.service
     lxc exec u2 -- systemctl unmask dnsmasq
     lxc exec u2 -- systemctl start dnsmasq
 
@@ -958,7 +956,6 @@ interface-name=u1.lxd,eth0
 host-record=lxd.localdomain,127.0.0.1
 EOF
 
-    lxc exec u1 -- rm /run/systemd/system/dnsmasq.service
     lxc exec u1 -- systemctl unmask dnsmasq
     lxc exec u1 -- systemctl start dnsmasq
     dig a +tcp @192.0.2.1 u1.lxd
@@ -997,7 +994,6 @@ interface-name=u2.lxd,eth0
 host-record=lxd.localdomain,127.0.0.2
 EOF
 
-    lxc exec u2 -- rm /run/systemd/system/dnsmasq.service
     lxc exec u2 -- systemctl unmask dnsmasq
     lxc exec u2 -- systemctl start dnsmasq
 


### PR DESCRIPTION
This reverts commit 8fa822b1511da18a88a6e194fc77bfeb7ceb2201.

The upstream image has now been fixed.

Signed-off: Thomas Parrott <thomas.parrott@canonical.com>