### PR TITLE
Fix openwrt dnsmasq/dhcp on boot

### DIFF
--- a/images/openwrt.yaml
+++ b/images/openwrt.yaml
@@ -349,7 +349,7 @@ actions:
     #!/bin/sh
 
     # Disable process isolation to make dnsmasq work
-    sed -i 's/procd_add_jail/# \0/g' /etc/init.d/dnsmasq
+    sed -i 's/procd_add_jail/: \0/g' /etc/init.d/dnsmasq
   releases:
   - snapshot
   - 22.03


### PR DESCRIPTION
Use noop instead of comment to remove calls to `procd_add_jail` so usages inside a shell pipeline don't result in syntax errors.

https://github.com/openwrt/openwrt/commit/936df715de3d33947ce38ca232b05c2bd3ef58f1 added a call to `procd_add_jail_mount` as part of a short-circuit test. Using a comment breaks the script.

Tested in a proxmox VM