### PR TITLE
Run cowsql job using the latest Zabbly kernel

### DIFF
--- a/bin/maas-kernel
+++ b/bin/maas-kernel
@@ -160,6 +160,24 @@ case "$i" in
         apt-get dist-upgrade --yes
       ;;
 
+      zabbly)
+        echo "===> Installing the current zabbly kernel"
+
+        cat<<EOF > /etc/apt/sources.list.d/zabbly-kernel-stable.sources
+Enabled: yes
+Types: deb deb-src
+URIs: https://pkgs.zabbly.com/kernel/stable
+Suites: $(lsb_release -cs)
+Components: main
+Architectures: $(dpkg --print-architecture)
+Signed-By: /etc/apt/keyrings/zabbly.asc
+EOF
+        curl https://pkgs.zabbly.com/key.asc -o /etc/apt/keyrings/zabbly.asc
+
+        apt-get update
+        apt-get install --no-install-recommends --yes linux-zabbly
+      ;;
+
       *)
         echo "Unsupported kernel requested: ${1}"
         exit 1

--- a/jenkins/jobs/cowsql-benchmark.yaml
+++ b/jenkins/jobs/cowsql-benchmark.yaml
@@ -8,7 +8,7 @@
     builders:
     - shell: |-
         cd /lxc-ci
-        exec /lxc-ci/bin/maas-run name=lantea jammy ga-22.04 isolcpus bin/test-cowsql-benchmark
+        exec /lxc-ci/bin/maas-run name=lantea jammy ga-22.04 isolcpus,zabbly bin/test-cowsql-benchmark
 
     properties:
     - build-discarder:


### PR DESCRIPTION
This enables us to track performance improvements or regressions in latest kernel versions (in particular in `io_uring`-related code).
