### PR TITLE
bin/maas-kernel: Tweak the cpu set passed to isolcpus=

### DIFF
--- a/bin/maas-kernel
+++ b/bin/maas-kernel
@@ -43,7 +43,7 @@ case "$i" in
         echo "===> Isolate CPUs from the kernel scheduler"
 
         # shellcheck disable=SC2016
-        echo 'GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX} isolcpus=1,2,3"' > /etc/default/grub.d/99-isolcpus.cfg
+        echo 'GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX} isolcpus=6,7,8,9,10,11,18,19,20,21,22,23"' > /etc/default/grub.d/99-isolcpus.cfg
         update-grub
       ;;
 


### PR DESCRIPTION
This tweaks the set of CPUs passed to the isolcpus= kernel option.

This setting is taylor-made for lantea which has 2 sockets, with 6 physical cores each, and 2 hyper threads per core.

With the CPU set in this commit the kernel won't use the second socket at all, and all those 6 physical cores can be reserved for benchmarking.

We might need to make this value dynamic in the future, and not hard-coded/tailormade, but this is good enough for now.