### PR TITLE
Update openwrt.yaml - disable sysntpd service

### DIFF
--- a/images/openwrt.yaml
+++ b/images/openwrt.yaml
@@ -352,7 +352,8 @@ actions:
     sed -i 's/procd_add_jail/: \0/g' /etc/init.d/dnsmasq
     # Disable conflicting sysntpd service to avoid crash loop
     rm -f /etc/rc.d/*sysntpd
-  releases:
+
+releases:
   - snapshot
   - 22.03
   - 23.05

--- a/images/openwrt.yaml
+++ b/images/openwrt.yaml
@@ -350,6 +350,8 @@ actions:
 
     # Disable process isolation to make dnsmasq work
     sed -i 's/procd_add_jail/: \0/g' /etc/init.d/dnsmasq
+    # Disable conflicting sysntpd service to avoid crash loop
+    rm -f /etc/rc.d/*sysntpd
   releases:
   - snapshot
   - 22.03


### PR DESCRIPTION
Time is provided by host anyway. This avoids a crash loop and process isolation errors.

Specifically, this deletes the symlink in /etc/rc.d that marks a service as "enabled", i.e. setting it disabled. Wildcard notation to catch potential future updates in START/STOP sequence.

See #586 