### PR TITLE
test-incus-cgroup: Fix ingress test

### DIFF
--- a/bin/test-incus-cgroup
+++ b/bin/test-incus-cgroup
@@ -202,7 +202,7 @@ incus exec c1 -- iperf3 -R -c "${IP}" -J > iperf.json
 I2=$(($(jq .end.sum_sent.bits_per_second < iperf.json | cut -d. -f1)/1024/1024))
 echo "Throughput after limits: ${E2}Mbps / ${I2}Mbps"
 [ "${E2}" -lt "50" ]
-[ "${E2}" -lt "200" ]
+[ "${I2}" -lt "200" ]
 
 pkill -9 iperf3
 incus config device set c1 eth0 limits.egress= limits.ingress=


### PR DESCRIPTION
I noticed a typo in the last livestream. 