### PR TITLE
images/centos: Fix mirror for 9-Stream

### DIFF
--- a/images/centos.yaml
+++ b/images/centos.yaml
@@ -742,7 +742,7 @@ actions:
     cat << "EOF" > /etc/yum.repos.d/centos.repo
     [baseos]
     name=CentOS Stream $releasever - BaseOS
-    baseurl=https://mirror.xenyth.net/centos-stream/$stream/BaseOS/$basearch/os/
+    baseurl=https://mirror1.hs-esslingen.de/pub/Mirrors/centos-stream/$stream/BaseOS/$basearch/os/
     gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
     gpgcheck=1
     repo_gpgcheck=0
@@ -752,7 +752,7 @@ actions:
 
     [appstream]
     name=CentOS Stream $releasever - AppStream
-    baseurl=https://mirror.xenyth.net/centos-stream/$stream/AppStream/$basearch/os/
+    baseurl=https://mirror1.hs-esslingen.de/pub/Mirrors/centos-stream/$stream/AppStream/$basearch/os/
     metalink=https://mirrors.centos.org/metalink?repo=centos-appstream-$stream&arch=$basearch&protocol=https,http
     gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
     gpgcheck=1
@@ -765,7 +765,7 @@ actions:
     cat << "EOF" > /etc/yum.repos.d/centos-addons.repo
     [extras-common]
     name=CentOS Stream $releasever - Extras packages
-    baseurl=https://mirror.xenyth.net/centos-stream/SIGs/$stream/extras/$basearch/extras-common
+    baseurl=https://mirror1.hs-esslingen.de/pub/Mirrors/centos-stream/SIGs/$stream/extras/$basearch/extras-common
     gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Extras-SHA512
     gpgcheck=1
     repo_gpgcheck=0


### PR DESCRIPTION
The old mirror has out-of-date packages therefore we need to switch to a
mirror with the latest packages.
