### PR TITLE
jenkins/jobs: Drop Alpine Linux 3.15 (EOL)

### DIFF
--- a/jenkins/jobs/image-alpine.yaml
+++ b/jenkins/jobs/image-alpine.yaml
@@ -17,7 +17,6 @@
         name: release
         type: user-defined
         values:
-        - "3.15"
         - "3.16"
         - "3.17"
         - "3.18"


### PR DESCRIPTION
This removes Alpine Linux 3.15 as it has reached EOL.
