### PR TITLE
jenkins/jobs: Bump BusyBox to 1.36.1

### DIFF
--- a/jenkins/jobs/image-busybox.yaml
+++ b/jenkins/jobs/image-busybox.yaml
@@ -17,7 +17,7 @@
         name: release
         type: user-defined
         values:
-        - "1.34.1"
+        - "1.36.1"
 
     - axis:
         name: variant


### PR DESCRIPTION
This bumps the BusyBox version to 1.36.1.
