### PR TITLE
Fix: Ubuntu noble container netplan missing

### DIFF
--- a/images/ubuntu.yaml
+++ b/images/ubuntu.yaml
@@ -345,6 +345,7 @@ files:
   - jammy
   - lunar
   - mantic
+  - noble
   types:
   - container
   variants:


### PR DESCRIPTION
Fix: Ubuntu noble container netplan not being added to the image.