### PR TITLE
nixos: add stable version, rename current to unstable

### DIFF
--- a/bin/test-image
+++ b/bin/test-image
@@ -67,6 +67,11 @@ EOF
     fi
 else
     for PRIV in "priv" "unpriv"; do
+        if [ "${PRIV}" = "priv" ] && [ "${DIST}" = "nixos" ] && [ "${RELEASE}" = "23.11" ]; then
+            # NixOS 23.11 will never support privileged containers, but future versions do
+            continue
+        fi
+
         incus init "${TEST_IMAGE}" "${TEST_IMAGE}-${PRIV}"
         INSTANCES="${INSTANCES} ${TEST_IMAGE}-${PRIV}"
 

--- a/jenkins/jobs/image-nixos.yaml
+++ b/jenkins/jobs/image-nixos.yaml
@@ -17,7 +17,8 @@
         name: release
         type: user-defined
         values:
-        - current
+        - unstable
+        - 23.11
 
     - axis:
         name: variant
@@ -36,7 +37,8 @@
 
         exec sudo /lxc-ci/bin/build-distro /lxc-ci/images/nixos.yaml \
             ${INCUS_ARCHITECTURE} container 14400 ${WORKSPACE} \
-            -o image.architecture=${ARCH}
+            -o image.architecture=${ARCH} \
+            -o image.release=${release}
 
     properties:
     - build-discarder:


### PR DESCRIPTION
NixOS uses the label `unstable` for the current rolling release, follow that.

Add 23.11 stable release, which due to release timing did not get the privileged container systemd generator fix.

Unstable and later releases, 24.05 and beyond, will work out of the box.

Depends on: https://github.com/lxc/distrobuilder/pull/798

Part of: https://github.com/lxc/lxc-ci/issues/786
