### PR TITLE
nixos: Add support for stable release VM images

### DIFF
--- a/jenkins/jobs/image-nixos.yaml
+++ b/jenkins/jobs/image-nixos.yaml
@@ -35,10 +35,11 @@
         [ "${ARCH}" = "amd64" ] && ARCH="x86_64"
         [ "${ARCH}" = "arm64" ] && ARCH="aarch64"
 
+        RELEASE=${release}
+        [ "${RELEASE}" = "unstable" ] && JOBSET="trunk-combined" || JOBSET="release-${RELEASE}"
+
         # download a pre-built VM image
-        if [ "${release}" = "unstable" ]; then
-          curl --location --output ${WORKSPACE}/disk.qcow2 https://hydra.nixos.org/job/nixos/trunk-combined/nixos.lxdVirtualMachineImage.${ARCH}-linux/latest/download-by-type/file/qcow2-image
-        fi
+        curl --location --output ${WORKSPACE}/disk.qcow2 https://hydra.nixos.org/job/nixos/${JOBSET}/nixos.lxdVirtualMachineImage.${ARCH}-linux/latest/download-by-type/file/qcow2-image
 
         exec sudo /lxc-ci/bin/build-distro /lxc-ci/images/nixos.yaml \
             ${INCUS_ARCHITECTURE} container 14400 ${WORKSPACE} \


### PR DESCRIPTION
We now also expose a stable reference for the NixOS stable release VM images.

https://hydra.nixos.org/job/nixos/release-23.11/nixos.lxdVirtualMachineImage.aarch64-linux/latest/download-by-type/file/qcow2-image
https://hydra.nixos.org/job/nixos/release-23.11/nixos.lxdVirtualMachineImage.x86_64-linux/latest/download-by-type/file/qcow2-image

cc @adamcstephens 

Closes: #786 