### PR TITLE
Fix debian build

### DIFF
--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -1275,8 +1275,7 @@ packages:
     - s390x
   - name: sources.list
     url: |-
-      deb http://ftp.ports.debian.org/debian-ports unstable main
-      deb http://ftp.ports.debian.org/debian-ports unreleased main
+      deb http://deb.debian.org/debian sid main
     architectures:
     - riscv64
 


### PR DESCRIPTION
Hi,

This change fix build of debian for LXC in sid version. Build OK & Tested on riscv64

You can try on your side with this way : 

```
apt install -y golang-go debootstrap rsync gpg squashfs-tools git
git clone https://github.com/lxc/distrobuilder
cd distrobuilder || exit
make
wget https://raw.githubusercontent.com/lxc/lxc-ci/main/images/debian.yaml
$HOME/go/bin/distrobuilder build-lxc -o image.architecture=riscv64 -o image.release=sid debian.yaml
```

Best Regards