### PR TITLE
Add Network compatibility on debian

### DIFF
--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -1183,6 +1183,7 @@ packages:
   - packages:
     - dbus
     - systemd-resolved
+    - ifupdown2
     action: install
     early: true
     releases:
@@ -1478,6 +1479,7 @@ actions:
     #!/bin/sh
     set -eux
 
+    mkdir -p /etc/network
     umount -l /etc/resolv.conf || true
     ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
   releases:


### PR DESCRIPTION
This changes.

Fix possibility to work on pct with PVE.
`ifupdown2` help to set/reload ip configuration also for what `ifupdown2` and not `ifupdown` because `ifupdown` is now deprecated on next debian release.
This change `/etc/network` fix possibility to add compatibility for add or not `interfaces` file in this folder.

Build OK / Test OK

Best Regards