### PR TITLE
images/gentoo: vm and installkernel related updates

### DIFF
--- a/images/gentoo.yaml
+++ b/images/gentoo.yaml
@@ -295,7 +295,7 @@ source:
 targets:
   incus:
     vm:
-      size: 4718592000
+      size: 6442450944
       filesystem: ext4
 
   lxc:
@@ -572,7 +572,7 @@ actions:
     systemd-machine-id-setup
     bootctl install --no-variables --esp-path=/boot/efi/
 
-    echo "sys-kernel/installkernel dracut" >> /etc/portage/package.use/installkernel
+    echo "sys-kernel/installkernel dracut systemd systemd-kernel-install" >> /etc/portage/package.use/installkernel
     emerge gentoo-kernel-bin
 
     rm -f /etc/machine-id /var/lib/dbus/machine-id
@@ -581,6 +581,17 @@ actions:
   - vm
   variants:
   - systemd
+
+- trigger: post-files
+  action: |-
+    #!/bin/sh
+    echo "sys-kernel/installkernel dracut" >> /etc/portage/package.use/installkernel
+    emerge gentoo-kernel-bin
+
+  types:
+  - vm
+  variants:
+  - openrc
 
 - trigger: post-packages
   action: |-


### PR DESCRIPTION
 - Added logic to enable `dracut` use flag on openrc variant's **installkernel** package.
 - Bumped the size to 6 GB. This is just a guess, but generally software getting larger and larger won't probably take long for this to not be enough.
 - Updated systemd variants **installkernel** to also enable use flag for `systemd-kernel-install` - the `systemd` use flag will be renamed to `systemd-kernel-install` some time soon. This allows both to be enabled, getting cleanly through the migration phase. Rationale was that on systemd profiles the `+systemd` use flag is always enabled, causing issues when using **installkernel** and **grub**.

I could successfully build openrc and systemd vm's with this update, although I didn't try to launch them.