### PR TITLE
images/gentoo: installkernel >=20 updates

### DIFF
--- a/images/gentoo.yaml
+++ b/images/gentoo.yaml
@@ -572,7 +572,10 @@ actions:
     systemd-machine-id-setup
     bootctl install --no-variables --esp-path=/boot/efi/
 
-    echo "sys-kernel/installkernel dracut systemd systemd-kernel-install" >> /etc/portage/package.use/installkernel
+    echo "root=/dev/sda2" >> /etc/kernel/cmdline
+
+    echo "sys-apps/systemd kernel-install" >> /etc/portage/package.use/systemd
+    echo "sys-kernel/installkernel dracut systemd systemd-boot" >> /etc/portage/package.use/installkernel
     emerge gentoo-kernel-bin
 
     rm -f /etc/machine-id /var/lib/dbus/machine-id
@@ -585,7 +588,7 @@ actions:
 - trigger: post-files
   action: |-
     #!/bin/sh
-    echo "sys-kernel/installkernel dracut" >> /etc/portage/package.use/installkernel
+    echo "sys-kernel/installkernel dracut grub" >> /etc/portage/package.use/installkernel
     emerge gentoo-kernel-bin
 
   types:


### PR DESCRIPTION
 - add "grub" use flag with openrc (I forgot this last time),
 - "systemd-kernel-install" was settled with "systemd-boot" instead on systemd.

NOTE: I couldn't boot the systemd variant, but openrc fully works. I'm gonna need some time to study systemd-boot as I've never dealt with it before. However the `systemd-boot` use flag looks final, so this should still be merged **if** systemd-boot is to be used in future with systemd vm variants.