### PR TITLE
Kali: Add non-free-firmware

### DIFF
--- a/images/kali.yaml
+++ b/images/kali.yaml
@@ -1747,7 +1747,7 @@ packages:
   repositories:
   - name: sources.list
     url: |-
-      deb http://kali.download/kali {{ image.release }} main non-free contrib
+      deb http://kali.download/kali {{ image.release }} main contrib non-free non-free-firmware
 
 actions:
 - trigger: post-packages


### PR DESCRIPTION
Source: https://www.kali.org/blog/non-free-firmware-transition/