### PR TITLE
Fixed space missing around dracut add_drivers+=

### DIFF
--- a/images/centos.yaml
+++ b/images/centos.yaml
@@ -350,7 +350,7 @@ files:
 - path: /etc/dracut.conf.d/incus.conf
   generator: dump
   content: |-
-    add_drivers+="virtio_scsi virtio_pci virtio_console"
+    add_drivers+=" virtio_scsi virtio_pci virtio_console "
   types:
   - vm
   releases:
@@ -359,7 +359,7 @@ files:
 - path: /etc/dracut.conf.d/incus.conf
   generator: dump
   content: |-
-    add_drivers+="virtio_scsi virtio_console sd_mod"
+    add_drivers+=" virtio_scsi virtio_console sd_mod "
   types:
   - vm
   releases:

--- a/images/fedora.yaml
+++ b/images/fedora.yaml
@@ -58,7 +58,7 @@ files:
 - path: /etc/dracut.conf.d/incus.conf
   generator: dump
   content: |-
-    add_drivers+=virtio_scsi
+    add_drivers+=" virtio_scsi "
   types:
   - vm
 

--- a/images/openeuler.yaml
+++ b/images/openeuler.yaml
@@ -130,7 +130,7 @@ files:
 - path: /etc/dracut.conf.d/incus.conf
   generator: dump
   content: |-
-    add_drivers+="virtio_scsi virtio_console sd_mod"
+    add_drivers+=" virtio_scsi virtio_console sd_mod "
   types:
   - vm
 

--- a/images/springdalelinux.yaml
+++ b/images/springdalelinux.yaml
@@ -186,7 +186,7 @@ files:
 - path: /etc/dracut.conf.d/incus.conf
   generator: dump
   content: |-
-    add_drivers+="virtio_scsi virtio_pci virtio_console"
+    add_drivers+=" virtio_scsi virtio_pci virtio_console "
   types:
   - vm
   releases:
@@ -195,7 +195,7 @@ files:
 - path: /etc/dracut.conf.d/incus.conf
   generator: dump
   content: |-
-    add_drivers+="virtio_scsi virtio_console sd_mod"
+    add_drivers+=" virtio_scsi virtio_console sd_mod "
   types:
   - vm
   releases:


### PR DESCRIPTION
Or the dracut will report the space missing error and the drivers planning added would not be added.