### PR TITLE
Fixed hardcoded root partition device name sda2

### DIFF
--- a/images/almalinux.yaml
+++ b/images/almalinux.yaml
@@ -409,7 +409,7 @@ actions:
     target="$(readlink -f /etc/grub2-efi.cfg)"
     grub2-mkconfig -o "${target}"
 
-    sed -i "s#root=[^ ]*#root=/dev/sda2#g" "${target}"
+    sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" "${target}"
   types:
   - vm
   releases:
@@ -424,11 +424,11 @@ actions:
 
     # Create grub.cfg file
     grub2-mkconfig -o "${target}"
-    sed -i "s#root=[^ ]*#root=/dev/sda2#g" "${target}"
+    sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" "${target}"
 
     # Update files in /boot/loader/entries/. `grubby` needs to be run after
     # `grub2-mkconfig` as the latter overwrites files in /boot/loader/entries/.
-    grubby --update-kernel=/boot/vmlinuz-${kver} --args="root=/dev/sda2 ro"
+    grubby --update-kernel=/boot/vmlinuz-${kver} --args="root=${DISTROBUILDER_ROOT_UUID} ro"
 
     # Regenerate initramfs
     dracut --kver "${kver}" -f

--- a/images/alpine.yaml
+++ b/images/alpine.yaml
@@ -386,7 +386,7 @@ actions:
 
     target=/boot/grub/grub.cfg
     grub-mkconfig -o "${target}"
-    sed -i "s#root=[^ ]*#root=/dev/sda2#g" "${target}"
+    sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" "${target}"
 
     TARGET="x86_64"
     [ "$(uname -m)" = "aarch64" ] && TARGET="arm64"

--- a/images/archlinux.yaml
+++ b/images/archlinux.yaml
@@ -796,7 +796,7 @@ actions:
     grub-install --target="${TARGET}-efi" --efi-directory=/boot/efi --no-nvram --removable
     grub-install --target="${TARGET}-efi" --efi-directory=/boot/efi --no-nvram
     grub-mkconfig -o /boot/grub/grub.cfg
-    sed -i "s#root=[^ ]*#root=/dev/sda2#g" /boot/grub/grub.cfg
+    sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" /boot/grub/grub.cfg
 
     # Rebuild initrd
     sed -i 's#^MODULES=.*#MODULES=(virtio_pci virtio_scsi virtio_console)#' /etc/mkinitcpio.conf

--- a/images/centos.yaml
+++ b/images/centos.yaml
@@ -831,7 +831,7 @@ actions:
 
     umount /sys/firmware
 
-    sed -i "s#root=[^ ]*#root=/dev/sda2#g" "${target}"
+    sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" "${target}"
 
     # Workaround for broken systemd in centos7
     systemctl enable incus-agent-workaround.service
@@ -852,7 +852,7 @@ actions:
     target="$(readlink -f /etc/grub2-efi.cfg)"
     grub2-mkconfig -o "${target}"
 
-    sed -i "s#root=[^ ]*#root=/dev/sda2#g" "${target}"
+    sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" "${target}"
   types:
   - vm
   releases:
@@ -867,11 +867,11 @@ actions:
 
     # Create grub.cfg file
     grub2-mkconfig -o "${target}"
-    sed -i "s#root=[^ ]*#root=/dev/sda2#g" "${target}"
+    sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" "${target}"
 
     # Update files in /boot/loader/entries/. `grubby` needs to be run after
     # `grub2-mkconfig` as the latter overwrites files in /boot/loader/entries/.
-    grubby --update-kernel=/boot/vmlinuz-${kver} --args="root=/dev/sda2 ro"
+    grubby --update-kernel=/boot/vmlinuz-${kver} --args="root=${DISTROBUILDER_ROOT_UUID} ro"
 
     # Regenerate initramfs
     dracut --kver "${kver}" -f

--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -1478,7 +1478,7 @@ actions:
     grub-install --uefi-secure-boot --target="${TARGET}-efi" --no-nvram
 
     update-grub
-    sed -i "s#root=[^ ]*#root=/dev/sda2#g" /boot/grub/grub.cfg
+    sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" /boot/grub/grub.cfg
   types:
   - vm
   releases:

--- a/images/fedora.yaml
+++ b/images/fedora.yaml
@@ -353,7 +353,7 @@ actions:
 
     target=/boot/efi/EFI/fedora/grub.cfg
     grub2-mkconfig -o "${target}"
-    sed -i "s#root=[^ ]*#root=/dev/sda2#g" "${target}"
+    sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" "${target}"
 
     sed -Eri "s#^(linux|initrd) .+/overlay/#\1 /#g" /boot/loader/entries/*
     sed -ri 's#^options .+#options $kernelopts#g' /boot/loader/entries/*

--- a/images/gentoo.yaml
+++ b/images/gentoo.yaml
@@ -578,7 +578,7 @@ actions:
     systemd-machine-id-setup
     bootctl install --no-variables --esp-path=/boot/efi/
 
-    echo "root=/dev/sda2" >> /etc/kernel/cmdline
+    echo "root=${DISTROBUILDER_ROOT_UUID}" >> /etc/kernel/cmdline
 
     echo "sys-apps/systemd kernel-install" >> /etc/portage/package.use/systemd
     echo "sys-kernel/installkernel dracut systemd systemd-boot" >> /etc/portage/package.use/installkernel
@@ -668,7 +668,7 @@ actions:
     grub-install --target=${TARGET}-efi --no-nvram --removable
     grub-install --target=${TARGET}-efi --no-nvram
     grub-mkconfig -o /boot/grub/grub.cfg
-    sed -i "s#root=[^ ]*#root=/dev/sda2#g" /boot/grub/grub.cfg
+    sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" /boot/grub/grub.cfg
   types:
   - vm
   variants:

--- a/images/openeuler.yaml
+++ b/images/openeuler.yaml
@@ -357,7 +357,7 @@ actions:
 
     umount /sys/firmware
 
-    sed -i "s#root=[^ ]*#root=/dev/sda2#g" "${target}"
+    sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" "${target}"
 
     # Workaround for broken systemd in centos7
     systemctl enable incus-agent-workaround.service

--- a/images/opensuse.yaml
+++ b/images/opensuse.yaml
@@ -409,7 +409,7 @@ actions:
 
     grub2-mkconfig -o /boot/grub2/grub.cfg
     umount /sys/firmware
-    sed -i "s#root=[^ ]*#root=/dev/sda2#g" /boot/grub2/grub.cfg
+    sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" /boot/grub2/grub.cfg
   types:
   - vm
 

--- a/images/rockylinux.yaml
+++ b/images/rockylinux.yaml
@@ -360,7 +360,7 @@ actions:
     dracut --kver "${kver}" -f
     target="$(readlink -f /etc/grub2-efi.cfg)"
     grub2-mkconfig -o "${target}"
-    sed -i "s#root=[^ ]*#root=/dev/sda2#g" "${target}"
+    sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" "${target}"
   types:
   - vm
   releases:
@@ -374,10 +374,10 @@ actions:
     target=/boot/efi/EFI/rocky/grub.cfg
     # Create grub.cfg file
     grub2-mkconfig -o "${target}"
-    sed -i "s#root=[^ ]*#root=/dev/sda2#g" "${target}"
+    sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" "${target}"
     # Update files in /boot/loader/entries/. `grubby` needs to be run after
     # `grub2-mkconfig` as the latter overwrites files in /boot/loader/entries/.
-    grubby --update-kernel=/boot/vmlinuz-${kver} --args="root=/dev/sda2 ro"
+    grubby --update-kernel=/boot/vmlinuz-${kver} --args="root=${DISTROBUILDER_ROOT_UUID} ro"
     # Regenerate initramfs
     dracut --kver "${kver}" -f
   types:

--- a/images/springdalelinux.yaml
+++ b/images/springdalelinux.yaml
@@ -431,7 +431,7 @@ actions:
 
     umount /sys/firmware
 
-    sed -i "s#root=[^ ]*#root=/dev/sda2#g" "${target}"
+    sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" "${target}"
 
     # Workaround for broken systemd in centos7
     systemctl enable incus-agent-workaround.service
@@ -452,7 +452,7 @@ actions:
     target="$(readlink -f /etc/grub2-efi.cfg)"
     grub2-mkconfig -o "${target}"
 
-    sed -i "s#root=[^ ]*#root=/dev/sda2#g" "${target}"
+    sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" "${target}"
   types:
   - vm
   releases:

--- a/images/ubuntu.yaml
+++ b/images/ubuntu.yaml
@@ -713,7 +713,7 @@ actions:
     grub-install --uefi-secure-boot --target="${TARGET}-efi" --no-nvram
 
     update-grub
-    sed -i "s#root=[^ ]*#root=/dev/sda2#g" /boot/grub/grub.cfg
+    sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" /boot/grub/grub.cfg
   types:
   - vm
 


### PR DESCRIPTION
The root partition may not be /dev/sda2, for example if set the boot disk as the second disk, the root partition device name will be /dev/sdb2. It may be /dev/vda2 if not using san disk. The fix figured out the root partition device UUID and set the UUID as the root, the root partition device UUID keeps no change.

Depends on lxc/distrobuilder#830