### PR TITLE
add: e2fsprogs-extra to Alpine cloud

### DIFF
--- a/images/alpine.yaml
+++ b/images/alpine.yaml
@@ -315,6 +315,7 @@ packages:
   - packages:
     - cloud-init
     - openssh
+    - e2fsprogs-extra
     action: install
     variants:
     - cloud


### PR DESCRIPTION
When creating VM on incus with Alpine, I get in the logs `/var/log/cloud-init.log`:

```
 - cc_resizefs.py[DEBUG]: Resizing / (ext4) using resize2fs /dev/sda2
 - subp.py[DEBUG]: Running command ('resize2fs', '/dev/sda2') with allowed return codes [0] (shell=False, capture=True)
 - util.py[WARNING]: Failed to resize filesystem (cmd=('resize2fs', '/dev/sda2'))
 - util.py[DEBUG]: Failed to resize filesystem (cmd=('resize2fs', '/dev/sda2'))
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/cloudinit/subp.py", line 280, in subp
    sp = subprocess.Popen(
         ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.11/subprocess.py", line 1955, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: b'resize2fs'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/cloudinit/config/cc_resizefs.py", line 328, in do_resize
    subp.subp(resize_cmd)
  File "/usr/lib/python3.11/site-packages/cloudinit/subp.py", line 293, in subp
    raise ProcessExecutionError(
cloudinit.subp.ProcessExecutionError: Unexpected error while running command.
Command: ('resize2fs', '/dev/sda2')
Exit code: -
Reason: [Errno 2] No such file or directory: b'resize2fs'
Stdout: -
Stderr: -
```

Could the `resize2fs` command be included in the base image please?