### PR TITLE
Revert "debian: Disable trixie (not debootstrapable)"

### DIFF
--- a/jenkins/jobs/image-debian.yaml
+++ b/jenkins/jobs/image-debian.yaml
@@ -22,7 +22,7 @@
         - bullseye
 #        - sid
         - bookworm
-#        - trixie
+        - trixie
 
     - axis:
         name: variant


### PR DESCRIPTION
This reverts commit 7b25a9c4d239b56e7a0f0946b0eddb245f3ef6c2.  It seems to work again now.