### PR TITLE
openeuler: Switch to Berkeley OCF mirror

### DIFF
--- a/images/openeuler.yaml
+++ b/images/openeuler.yaml
@@ -4,7 +4,7 @@ image:
     openEuler {{ image.release }}
 source:
   downloader: openeuler-http
-  url: https://repo.openeuler.org
+  url: https://mirrors.ocf.berkeley.edu/openeuler
 targets:
   lxc:
     create_message: |


### PR DESCRIPTION
Connectivity from builders to the primary mirror has been flaky:

```
+ distrobuilder --cache-dir /root/build/cache/ --timeout 7200 build-dir image.yaml rootfs -o image.serial=20240906_18:19 -o image.architecture=aarch64 -o image.release=24.03 -o image.variant=default time="2024-09-06T18:19:22Z" level=info msg="Downloading source" Error: Error while downloading source: Failed to download https://repo.openeuler.org/openEuler-24.03-LTS/ISO/aarch64/openEuler-24.03-LTS-aarch64-dvd.iso: stream error: stream ID 7; INTERNAL_ERROR; received from peer time="2024-09-06T18:47:35Z" level=error msg="Failed running distrobuilder" err="Error while downloading source: Failed to download https://repo.openeuler.org/openEuler-24.03-LTS/ISO/aarch64/openEuler-24.03-LTS-aarch64-dvd.iso: stream error: stream ID 7; INTERNAL_ERROR; received from peer" time="2024-09-06T18:47:35Z" level=info msg="Removing cache directory"
```

Fixes #843