### PR TITLE
jenkins: Build Fedora 41 Imgaes

### DIFF
--- a/jenkins/jobs/image-fedora.yaml
+++ b/jenkins/jobs/image-fedora.yaml
@@ -19,6 +19,7 @@
           values:
             - 39
             - 40
+            - 41
 
       - axis:
           name: variant


### PR DESCRIPTION
Fedora 41 Released 10/29/24

https://fedoramagazine.org/announcing-fedora-linux-41/