### PR TITLE
Revert "openeuler: Switch to Berkeley OCF mirror"

### DIFF
--- a/images/openeuler.yaml
+++ b/images/openeuler.yaml
@@ -4,7 +4,7 @@ image:
     openEuler {{ image.release }}
 source:
   downloader: openeuler-http
-  url: https://mirrors.ocf.berkeley.edu/openeuler
+  url: https://repo.openeuler.org
 targets:
   lxc:
     create_message: |


### PR DESCRIPTION
This reverts commit 7358d9f4ebb0a30233aaee56ad4513dc2e226819.

The Berkeley OCF mirror is currently missing files and 404ing for paths like https://mirrors.ocf.berkeley.edu/openeuler/openEuler-24.03-LTS-SP1/ISO/aarch64/openEuler-24.03-LTS-SP1-aarch64-dvd.iso