### PR TITLE
Update debian.yaml

### DIFF
--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -1222,7 +1222,7 @@ packages:
     - bullseye
 
   - packages:
-    - polkit
+    - polkitd
     action: install
     architectures:
     - amd64


### PR DESCRIPTION
debian: add polkitd for trixie

Corrects typo `polkit` -> `polkitd` vs. https://github.com/lxc/lxc-ci/pull/864#issuecomment-2626117275

(https://packages.debian.org/trixie/polkitd)
