### PR TITLE
images/gentoo.yaml: prepare for dracut-106's hostonly change

### DIFF
--- a/images/gentoo.yaml
+++ b/images/gentoo.yaml
@@ -547,8 +547,11 @@ actions:
 
     echo "root=${DISTROBUILDER_ROOT_UUID}" >> /etc/kernel/cmdline
 
+    mkdir -p /etc/dracut.conf.d/
+
     echo "sys-apps/systemd kernel-install" >> /etc/portage/package.use/systemd
     echo "sys-kernel/installkernel dracut systemd systemd-boot" >> /etc/portage/package.use/installkernel
+    echo "hostonly=no" >> /etc/dracut.conf.d/95-no-hostonly.conf
     emerge gentoo-kernel-bin
 
     rm -f /etc/machine-id /var/lib/dbus/machine-id
@@ -561,7 +564,9 @@ actions:
 - trigger: post-files
   action: |-
     #!/bin/sh
+    mkdir -p /etc/dracut.conf.d/
     echo "sys-kernel/installkernel dracut grub" >> /etc/portage/package.use/installkernel
+    echo "hostonly=no" >> /etc/dracut.conf.d/95-no-hostonly.conf
     emerge gentoo-kernel-bin
 
   types:


### PR DESCRIPTION
Summary from the Gentoo News item:
"Starting with version 106 of sys-kernel/dracut the default for the "hostonly" setting has changed from disabled to enabled when Dracut is invoked via installkernel.

"hostonly" is a setting for Dracut that controls how much is included in the generated initramfs image. When it is disabled Dracut aims to generate an initramfs image that is bootable on any hardware. On the other hand, when this setting is enabled, Dracut aims to generate an initramfs image containing only what is needed to boot the current system. The advantage is a significantly smaller initramfs images, but this comes with the cost of losing portability."

dracut-ng/dracut-ng#1158
https://www.gentoo.org/support/news-items/2025-02-03-dracut-hostonly.html

Note:
 - This change is relevant only for the vm variant images.
 - It will take a while before dracut-106 is stabilized and therefore used by distrobuilder.