### PR TITLE
Add jenkins job for building Alt vm

### DIFF
--- a/jenkins/jobs/image-alt.yaml
+++ b/jenkins/jobs/image-alt.yaml
@@ -34,9 +34,16 @@
         INCUS_ARCHITECTURE="${architecture}"
 
         ARCH=${architecture}
+        [ "${ARCH}" = "amd64" ] && ARCH="x86_64"
+        [ "${ARCH}" = "arm64" ] && ARCH="aarch64"
+
+        TYPE="container"
+        if [ "${architecture}" = "amd64" ] || [ "${architecture}" = "arm64" ]; then
+            TYPE="container,vm"
+        fi
 
         exec sudo /lxc-ci/bin/build-distro /lxc-ci/images/alt.yaml \
-            ${INCUS_ARCHITECTURE} container 3600 ${WORKSPACE} \
+            ${INCUS_ARCHITECTURE} ${TYPE} 3600 ${WORKSPACE} \
             -o image.variant=${variant} \
             -o image.release=${release} -o image.architecture=${ARCH}
 


### PR DESCRIPTION
This PR adds code to jenkins job for building Alt virtual mashines, the support of which was added in the `793300b` commit.