### PR TITLE
Remove Alt P10 release from jenkins jobs

### DIFF
--- a/jenkins/jobs/image-alt.yaml
+++ b/jenkins/jobs/image-alt.yaml
@@ -19,7 +19,6 @@
         values:
         - Sisyphus
         - p11
-        - p10
 
     - axis:
         name: variant


### PR DESCRIPTION
This PR removes building of p10 platform of Alt Linux. It is not supported no more.