### PR TITLE
Add sg driver to kernet in Alt distribution

### DIFF
--- a/images/alt.yaml
+++ b/images/alt.yaml
@@ -161,7 +161,7 @@ files:
 - path: /etc/dracut.conf.d/incus.conf
   generator: dump
   content: |-
-    add_drivers+=" virtio_scsi virtio_pci sd_mod virtio_blk "
+    add_drivers+=" virtio_scsi virtio_pci sd_mod sg virtio_blk "
   types:
   - vm
 


### PR DESCRIPTION
This PR adds 'sg' driver to kernel in Alt distribution to try running it from images.linuxcontainers.org.