### PR TITLE
test-image: fix typo causing the script to fail silently

### DIFF
--- a/bin/test-image
+++ b/bin/test-image
@@ -163,7 +163,7 @@ for url in $(incus query "/1.0/instances" | jq -r .[] | grep "${TEST_IMAGE}"); d
             echo "===> DEBUG: systemd failed: ${name}"
             incus exec "${name}" -- systemctl --failed
             FAIL=1
-        else if incus exec "${name}" -- systemctl -a | grep -q ssh; then
+        elif incus exec "${name}" -- systemctl -a | grep -q ssh; then
             echo "===> FAIL: systemd clean: SSH server present"
         else
             echo "===> PASS: systemd clean: ${name}"


### PR DESCRIPTION
Context: https://discuss.linuxcontainers.org/t/sharing-directory-with-debian-13-vm-does-not-work/23361