### PR TITLE
alpine: enable ppc64el and s390x

### DIFF
--- a/jenkins/jobs/image-alpine.yaml
+++ b/jenkins/jobs/image-alpine.yaml
@@ -14,6 +14,8 @@
         - arm64
         - armhf
         - riscv64
+        - ppc64el
+        - s390x
 
     - axis:
         name: release
@@ -41,6 +43,7 @@
         [ "${ARCH}" = "amd64" ] && ARCH="x86_64"
         [ "${ARCH}" = "arm64" ] && ARCH="aarch64"
         [ "${ARCH}" = "armhf" ] && ARCH="armv7"
+        [ "${ARCH}" = "ppc64el" ] && ARCH="ppc64le"
 
         TYPE="container"
         if [ "${architecture}" = "amd64" ] || [ "${architecture}" = "arm64" ]; then


### PR DESCRIPTION
Both archtectures are supported for all non-EOL Alpine versions. The baseline for s390x is z196 and therefore works with the z13 builder.