### PR TITLE
deps/lxc-exercise: re-enable some tests

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: read  # for tim-actions/get-pr-commits to get list of commits from the PR
     name: Signed-off-by (DCO)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Get PR Commits
       id: 'get-pr-commits'
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: none
     name: Branch target
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Check branch target
       env:

--- a/deps/lxc-exercise
+++ b/deps/lxc-exercise
@@ -112,28 +112,9 @@ for testbin in lxc-test-*; do
             ignore "$STRING" && continue
     fi
 
-    # Skip some tests because of broken busybox
-    [ "$testbin" = "lxc-test-state-server" ] && \
+    # Skip lxc-test-no-new-privs as it is broken
+    [ "$testbin" = "lxc-test-no-new-privs" ] && \
         ignore "$STRING" && continue
-
-    # Skip some tests due to cgroup v2 incompatibility
-    if [ -e /sys/fs/cgroup/system.slice/memory.current ]; then
-
-        [ "$testbin" = "lxc-test-apparmor-mount" ] && \
-            ignore "$STRING" && continue
-
-        [ "$testbin" = "lxc-test-autostart" ] && \
-            ignore "$STRING" && continue
-
-        [ "$testbin" = "lxc-test-no-new-privs" ] && \
-            ignore "$STRING" && continue
-
-        [ "$testbin" = "lxc-test-unpriv" ] && \
-            ignore "$STRING" && continue
-
-        [ "$testbin" = "lxc-test-usernic" ] && \
-            ignore "$STRING" && continue
-    fi
 
     OUT="$(mktemp)"
     START_TIME="$(date +%s)"


### PR DESCRIPTION
Re-enable:
- lxc-test-apparmor-mount
- lxc-test-autostart
- lxc-test-unpriv
- lxc-test-usernic
- lxc-test-state-server

back as they pass without any problems.

Keep `lxc-test-no-new-privs` test disabled as it is still broken.

Requires https://github.com/lxc/lxc/pull/4549