### PR TITLE
deps/lxc-exercise: re-enable lxc-test-no-new-privs

### DIFF
--- a/deps/lxc-exercise
+++ b/deps/lxc-exercise
@@ -112,10 +112,6 @@ for testbin in lxc-test-*; do
             ignore "$STRING" && continue
     fi
 
-    # Skip lxc-test-no-new-privs as it is broken
-    [ "$testbin" = "lxc-test-no-new-privs" ] && \
-        ignore "$STRING" && continue
-
     OUT="$(mktemp)"
     START_TIME="$(date +%s)"
     if "./$testbin" > "$OUT" 2>&1; then


### PR DESCRIPTION
We should re-enable this one too.

Simon Deziel (<simon.deziel@canonical.com>) was doing an independent investigation of another failures with LXD and it turned out that [1] introduces lxc exec command regressions.

Also, this commit breaks lxc-test-no-new-privs test which was disabled for a while since we migrated from Jenkins self-hosted runners to a GitHub Actions ones.

[1] https://github.com/lxc/lxc/commit/50dee37cfe3201ed51f477356f81941c960a5511