### PR TITLE
alpine: remove needless install of gcc in vm

### DIFF
--- a/images/alpine.yaml
+++ b/images/alpine.yaml
@@ -334,7 +334,6 @@ packages:
 
   - packages:
     - acpi
-    - gcc
     - grub-efi
     - linux-virt
     - udev


### PR DESCRIPTION
gcc was added to vm variant in commit aa865878c798 (images/alpine: Add Alpine VM support) but there was no explanation why it is needed. Nothing uses it and it is also more or less useless without libc headers. Remove it.

This reduces the size with 61%. (from 253MB to 97MB)