### PR TITLE
alpine: fix edge image

### DIFF
--- a/images/alpine.yaml
+++ b/images/alpine.yaml
@@ -341,6 +341,15 @@ packages:
     - vm
 
 actions:
+- trigger: post-unpack
+  action: |-
+    #!/bin/sh
+    set -eux
+
+    printf "disable_trigger=1\n" > /etc/update-grub.conf
+  types:
+  - vm
+
 - trigger: post-packages
   action: |-
     #!/bin/sh
@@ -383,6 +392,7 @@ actions:
         ln -fs /etc/init.d/${svc_name} /etc/runlevels/sysinit/${svc_name}
     done
 
+    mkdir -p /boot/grub
     target=/boot/grub/grub.cfg
     grub-mkconfig -o "${target}"
     sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" "${target}"
@@ -392,8 +402,8 @@ actions:
     grub-install --target=${TARGET}-efi --no-nvram --removable
     grub-install --target=${TARGET}-efi --no-nvram
 
-    # Attempt to correct errors in the installation of all packages.
-    apk fix
+    # re-enable grub trigger for future grub updates
+    rm /etc/update-grub.conf
   types:
   - vm
 


### PR DESCRIPTION
The grub apk trigger fails when it can not find the rootfs device, and the rootfs device is not found when executed in a container. Previously apk (version 2.x) has exited with success, even if trigger fails, but with apk certion 3.x, it now exits with failure, which caused the image of alpine edge fail after apk was upgraded to 3.

Fix this by disable the grub apk trigger before the grub package is installed, and rely on the distrobuilder's post-packages hook to generate the grub config.

Re-enable it after again so future upgrades of grub in VM will regenerate the config as needed.