### PR TITLE
Add image generation for AlmaLinux 10

### DIFF
--- a/images/almalinux.yaml
+++ b/images/almalinux.yaml
@@ -490,17 +490,22 @@ actions:
   action: |-
     #!/bin/sh
     set -eux
+
+    # Track down the kernel
     kver=$(basename /boot/initramfs-*.img | sed -r 's#initramfs-(.+)\.img#\1#' | head -n1)
     if [ -z "$kver" ]; then
       echo "No initramfs found in /boot!" >&2
       exit 1
     fi
+
     kernel_path=$(find /boot -name "vmlinuz-${kver}" || true)
     if [ -z "$kernel_path" ]; then
       echo "Kernel image /boot/vmlinuz-${kver} not found!" >&2
       ls -l /boot >&2
       exit 1
     fi
+
+    # Track down the root disk
     root_dev=$(df / | tail -n1 | awk '{print $1}')
     if [ -b "$root_dev" ]; then
       root_uuid=$(blkid -s UUID -o value "$root_dev")
@@ -512,25 +517,33 @@ actions:
       echo "Error: Root device $root_dev not found!" >&2
       exit 1
     fi
+
+    # Re-generate the initrd
     . /etc/os-release
     GRUB_ENTRY_NAME="${NAME} ${VERSION} ${kver}"
     dracut --kver "${kver}" -f --no-hostonly --add-drivers "virtio_scsi virtio_console sd_mod ext4 virtio_blk virtio_pci scsi_mod" --install "blkid"
+
+
+    # Track down the EFI partition
     disk_dev=$(lsblk -no pkname "$root_dev" | head -n1)
     if [ -z "$disk_dev" ]; then
       echo "Failed to find disk device for $root_dev" >&2
       exit 1
     fi
     disk_dev="/dev/$disk_dev"
+
     efi_part="${disk_dev}p1"
     if [ ! -b "$efi_part" ]; then
       echo "EFI partition $efi_part not found!" >&2
       exit 1
     fi
+
+    # Generate the grub configuration
     mkdir -p /mnt/efi
     mount "$efi_part" /mnt/efi
-    target=/mnt/efi/EFI/almalinux/grub.cfg
+
     mkdir -p /mnt/efi/EFI/almalinux
-    cat > "${target}" <<EOF
+    cat > "/mnt/efi/EFI/almalinux/grub.cfg" <<EOF
     set timeout=5
     set default=0
 
@@ -544,6 +557,7 @@ actions:
         fwsetup
     }
     EOF
+
     umount /mnt/efi
     mkdir -p /boot/grub2
     touch /boot/grub2/grubenv

--- a/images/almalinux.yaml
+++ b/images/almalinux.yaml
@@ -119,6 +119,38 @@ source:
     1WKL
     =jk2t
     -----END PGP PUBLIC KEY BLOCK-----
+
+  # RPM-GPG-KEY-AlmaLinux-10
+  - |-
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+    mQINBGaP6O8BEACvg8IlAxGayV8zOi9Ex+Pd8lrj2BrBzloG8ri84ORp9o8ojq7l
+    ykKmIElHe11cQD2Lf/a4lcQQ4Ec3baiD786X6K2eVSlBEAnZMzfjDg8R63SfsBuu
+    8Yk+lUyqlBrDnSDYaPruOAzLIz2r82ikIC1jDbipZsMFPFHPI4/hayyWxJ3oGxRe
+    0mbtYLB9ElEKngt+/hfo7JLklakbznyIRuVEF3VrZb91XC6r/idqfJoNyBXSKidj
+    z0IwqOhgkLUk84rzltDo3AzwGqusd7PEuhOmqinOhp0hMdXsztD4TVyhw82iXu/O
+    onOAObZTZYfM6Z8btmDqkoo0aT+oPPCuZ3yC/caU9dhvCSXET/CGoXc3hL55u9PV
+    qmcVm/mwvuEImEAvxVc0/dBzEUk+FwW8KsaN3HoUKrC4/NqgmaQz8/42np7u2j+B
+    OOJ4hAckNEdWd8rB86CYN00sdxnvLBsp8V3IwEqXLhGOoBsagy61Z8hKCM+siOGn
+    xmbbybgaLOs+DPlxt9LrtgLJHODwmD96oysUPJuA0lv8KMiSpId0tSpp9Wn/wHBG
+    kRgxGYfzQu7WRvRZqQaleft1JTXXOjNzPur0RkJyb3yFwAoxpePyo/WrupM41OHW
+    58cEqdC6riCnJcS4U84RLj+hwvufBVB7areQ75sETnKeyozZW+P16E1t/wARAQAB
+    tChBbG1hTGludXggT1MgMTAgPHBhY2thZ2VyQGFsbWFsaW51eC5vcmc+iQJMBBMB
+    CgA2FiEE7m23uY9b9e3Z2g3l3uXBHMKh5XIFAmaP6O8CGwMECwkIBwQVCgkIBRYC
+    AwEAAh4FAheAAAoJEN7lwRzCoeVy32AP/A2+KI+JhmsxnactSptkAWGyAAf1YBWW
+    Js2sc9OJdKj7uIkzszCx7c7VIVeF/VLijIYpM/zwUgir5S5SimzQmY+FumwbKIml
+    K5RBsoSog22i7Edho0MLa1pa6qvnKS0nkl9DEcu8EbMUhucWbxGnCG/22EEMTrY+
+    Si1IZNkDGtlBHHBKMC+STbqqTxtdy4tAd2NYwWh3sBIh6PF7T4NLRAugu7PZQr5K
+    amS4z2lV3ebshGjieA0Zoznwh0AXgN0gZ/0pC/LXI25gcgtrvkCyL8Fe0AyZUMd8
+    UvZXaRSsm3SkCUIlGjPrvuItn1D7tHmqVSCDKXDM2TqjfiRm1JF+2OFCBNvGz19V
+    LxWd/Gf+0qw0dtKxRMKzGh0mxXY40hjtmYZulrPxhG5itNDjStovgrevM1HBsXs9
+    ikrkOGQ0pFcqizTn4ZKAmMozEMuIuV89Vof2bBCg7pHT1FmXVdAaYJxb6a7A/CgN
+    qHjoh8AxBiGw/Q2NM4YJlUVhHqqd+/lUG3WJqACNEnqSlZkYQ3HqNNaKhHVbD4mN
+    q/g6v+f8aWWDZDsI6IAfbJUB+KPEnIvQJQleWuHrq7kcUMhEq3dwBMIoTVEHhUUr
+    RQKToSEM1rN7PcanaXQM2gy141dS7tFLxhapG8ug75LkIUnEOpPMtUjvrU1ZELGq
+    36vVHBB+dTDg
+    =tJCw
+    -----END PGP PUBLIC KEY BLOCK-----
   variant: minimal
 
 targets:

--- a/images/almalinux.yaml
+++ b/images/almalinux.yaml
@@ -490,6 +490,72 @@ actions:
   action: |-
     #!/bin/sh
     set -eux
+    kver=$(basename /boot/initramfs-*.img | sed -r 's#initramfs-(.+)\.img#\1#' | head -n1)
+    if [ -z "$kver" ]; then
+      echo "No initramfs found in /boot!" >&2
+      exit 1
+    fi
+    kernel_path=$(find /boot -name "vmlinuz-${kver}" || true)
+    if [ -z "$kernel_path" ]; then
+      echo "Kernel image /boot/vmlinuz-${kver} not found!" >&2
+      ls -l /boot >&2
+      exit 1
+    fi
+    root_dev=$(df / | tail -n1 | awk '{print $1}')
+    if [ -b "$root_dev" ]; then
+      root_uuid=$(blkid -s UUID -o value "$root_dev")
+      if [ -z "$root_uuid" ]; then
+        echo "Failed to get UUID for $root_dev" >&2
+        exit 1
+      fi
+    else
+      echo "Error: Root device $root_dev not found!" >&2
+      exit 1
+    fi
+    . /etc/os-release
+    GRUB_ENTRY_NAME="${NAME} ${VERSION} ${kver}"
+    dracut --kver "${kver}" -f --no-hostonly --add-drivers "virtio_scsi virtio_console sd_mod ext4 virtio_blk virtio_pci scsi_mod" --install "blkid"
+    disk_dev=$(lsblk -no pkname "$root_dev" | head -n1)
+    if [ -z "$disk_dev" ]; then
+      echo "Failed to find disk device for $root_dev" >&2
+      exit 1
+    fi
+    disk_dev="/dev/$disk_dev"
+    efi_part="${disk_dev}p1"
+    if [ ! -b "$efi_part" ]; then
+      echo "EFI partition $efi_part not found!" >&2
+      exit 1
+    fi
+    mkdir -p /mnt/efi
+    mount "$efi_part" /mnt/efi
+    target=/mnt/efi/EFI/almalinux/grub.cfg
+    mkdir -p /mnt/efi/EFI/almalinux
+    cat > "${target}" <<EOF
+    set timeout=5
+    set default=0
+
+    menuentry '${GRUB_ENTRY_NAME}' {
+        set root=(hd0,gpt2)
+        linux /boot/vmlinuz-${kver} root=UUID=${root_uuid} ro console=tty1 console=ttyS0
+        initrd /boot/initramfs-${kver}.img
+    }
+
+    menuentry 'UEFI Firmware Settings' {
+        fwsetup
+    }
+    EOF
+    umount /mnt/efi
+    mkdir -p /boot/grub2
+    touch /boot/grub2/grubenv
+  types:
+  - vm
+  releases:
+  - 10
+
+- trigger: post-files
+  action: |-
+    #!/bin/sh
+    set -eux
 
     systemctl enable NetworkManager.service
   types:

--- a/images/almalinux.yaml
+++ b/images/almalinux.yaml
@@ -319,7 +319,6 @@ packages:
     - cronie
     - cronie-noanacron
     - curl
-    - dhclient
     - glibc-langpack-en
     - glibc-locale-source
     - hostname
@@ -332,6 +331,13 @@ packages:
     - sudo
     - vim-minimal
     action: install
+
+  - packages:
+    - dhclient
+    action: install
+    releases: # dhclient is not available in 10
+    - 8
+    - 9
 
   - packages:
     - network-scripts
@@ -365,6 +371,7 @@ packages:
     - container
     releases:
     - 9
+    - 10
     variants:
     - default
 
@@ -496,7 +503,23 @@ actions:
     set -eux
 
     mkdir -p /etc/NetworkManager/conf.d/
-    printf "[main]\ndhcp=dhclient" > /etc/NetworkManager/conf.d/dhcp-client.conf
+    printf "[main]\ndhcp=internal\n" > /etc/NetworkManager/conf.d/dhcp-client.conf
+
+    systemctl enable NetworkManager.service
+  types:
+  - container
+  variants:
+  - default
+  releases:
+  - 10
+
+- trigger: post-files
+  action: |-
+    #!/bin/sh
+    set -eux
+
+    mkdir -p /etc/NetworkManager/conf.d/
+    printf "[main]\ndhcp=dhclient\n" > /etc/NetworkManager/conf.d/dhcp-client.conf
 
     systemctl enable NetworkManager.service
   types:

--- a/jenkins/jobs/image-almalinux.yaml
+++ b/jenkins/jobs/image-almalinux.yaml
@@ -19,6 +19,7 @@
         values:
         - 8
         - 9
+        - 10
 
     - axis:
         name: variant


### PR DESCRIPTION
The container image works (at least for `default`, I did not test `cloud`).

Regarding the VM image :
- it boots fine (but I don't understand why the approach used for v9 cannot be adapted for v10 -- I took the code from @MichaelStauber's version which works)
- however the agent does not start

At the end of boot, console shows:
```
[    9.036680] virtio-fs: tag <config> not found
[   14.317760] virtio-fs: tag <config> not found
[   19.396814] virtio-fs: tag <config> not found
[   24.647583] virtio-fs: tag <config> not found
[   29.897760] virtio-fs: tag <config> not found
[   35.140829] virtio-fs: tag <config> not found
[   40.395432] virtio-fs: tag <config> not found
[   45.644483] virtio-fs: tag <config> not found
[   50.893362] virtio-fs: tag <config> not found
```

The changes should not affect AlmaLinux 8 or 9.