### PR TITLE
debian: use DHCPv4 MTU option

### DIFF
--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -1009,6 +1009,7 @@ files:
 
     [DHCPv4]
     UseDomains=true
+    UseMTU=true
 
     [DHCP]
     ClientIdentifier=mac
@@ -1028,6 +1029,7 @@ files:
 
     [DHCPv4]
     UseDomains=true
+    UseMTU=true
 
     [DHCP]
     ClientIdentifier=mac


### PR DESCRIPTION
Enable UseMTU option in the systemd-networkd configuration so the MTU option injected by ie. an Incus OVN network gets applied to the NIC.