### PR TITLE
Centos: Fixes for post-files scripts

### DIFF
--- a/images/centos.yaml
+++ b/images/centos.yaml
@@ -635,6 +635,7 @@ packages:
 
   - packages:
     - grub2-efi-x64
+    - grubby
     action: install
     types:
     - vm

--- a/images/centos.yaml
+++ b/images/centos.yaml
@@ -927,6 +927,30 @@ actions:
     #!/bin/sh
     set -eux
 
+    mkdir -p /etc/NetworkManager/conf.d/
+    printf "[main]\ndhcp=internal\n" > /etc/NetworkManager/conf.d/dhcp-client.conf
+
+    systemctl enable NetworkManager.service
+  releases:
+  - 10-Stream
+
+- trigger: post-files
+  action: |-
+    #!/bin/sh
+    set -eux
+
+    mkdir -p /etc/NetworkManager/conf.d/
+    printf "[main]\ndhcp=dhclient\n" > /etc/NetworkManager/conf.d/dhcp-client.conf
+
+    systemctl enable NetworkManager.service
+  releases:
+  - 9-Stream
+
+- trigger: post-files
+  action: |-
+    #!/bin/sh
+    set -eux
+
     systemctl enable network
   types:
   - container
@@ -954,19 +978,6 @@ actions:
   - 8-Stream
   architectures:
   - armhfp
-
-- trigger: post-files
-  action: |-
-    #!/bin/sh
-    set -eux
-
-    mkdir -p /etc/NetworkManager/conf.d/
-    printf "[main]\ndhcp=dhclient" > /etc/NetworkManager/conf.d/dhcp-client.conf
-
-    systemctl enable NetworkManager.service
-  releases:
-  - 9-Stream
-  - 10-Stream
 
 - trigger: post-files
   action: |-


### PR DESCRIPTION
Latest build [failed](https://jenkins.linuxcontainers.org/job/image-centos/3917/architecture=amd64,release=10-Stream,variant=default/console) when trying to run the grubby command. That package is still available on [C9](https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/) & [C10](https://mirror.stream.centos.org/10-stream/BaseOS/x86_64/os/Packages/), just not explicitly brought in neither by the deps nor the base image.

Also fixed networking setup scripts, since we don't use dhclient on C10 anymore.