### PR TITLE
nixos: add 25.11 image

### DIFF
--- a/jenkins/jobs/image-nixos.yaml
+++ b/jenkins/jobs/image-nixos.yaml
@@ -18,6 +18,7 @@
         type: user-defined
         values:
         - unstable
+        - 25.11
         - 25.05
 
     - axis:


### PR DESCRIPTION
NixOS 25.11 isn't released yet but it will be only a couple of days (https://github.com/NixOS/nixpkgs/issues/443568). This should already work from what i can tell.

I would say 25.05 can be dropped at any point after 2025-12-31 since that's the EOL date.

cc @adamcstephens