### PR TITLE
nixos: write unstable serial file

### DIFF
--- a/jenkins/jobs/image-nixos.yaml
+++ b/jenkins/jobs/image-nixos.yaml
@@ -48,6 +48,9 @@
 
           # download a pre-built incus metadata
           curl --location --output $WORKSPACE/incus.tar.xz https://hydra.nixos.org/job/nixos/$JOBSET/nixos.incusContainerMeta.$ARCH-linux/latest/download-by-type/file/system-tarball
+
+          # write a serial used by publishing
+          date -u +%Y%m%d_%H:%M > serial
         else
           exec sudo /lxc-ci/bin/build-distro /lxc-ci/images/nixos.yaml \
               $INCUS_ARCHITECTURE container 14400 $WORKSPACE \


### PR DESCRIPTION
Pulled the date command from bin/build-distro. This won't match the serial in the metadata tarball, but maybe that's ok?