### PR TITLE
nixos: remove EOL 25.05 release

### DIFF
--- a/jenkins/jobs/image-nixos.yaml
+++ b/jenkins/jobs/image-nixos.yaml
@@ -19,7 +19,6 @@
         values:
         - unstable
         - 25.11
-        - 25.05
 
     - axis:
         name: variant


### PR DESCRIPTION
NixOS 25.05 is EOL since 2026-01-01