### PR TITLE
jenkins: re-enable alpine riscv64 and tinycloud variant

### DIFF
--- a/jenkins/jobs/image-alpine.yaml
+++ b/jenkins/jobs/image-alpine.yaml
@@ -58,9 +58,6 @@
             -o image.architecture=$ARCH -o image.release=$release \
             -o image.variant=$variant $EXTRA_ARGS
 
-    execution-strategy:
-      combination-filter: '!(architecture == "riscv64" || variant == "tinycloud")'
-
     properties:
     - build-discarder:
         num-to-keep: 3


### PR DESCRIPTION
The riscv64 and tinycloud were unintentionally disabled when upgrading to alpine 3.23.

Fixes commit 5944e31439b3 (alpine: add 3.23 and remove EOL 3.19)