### PR TITLE
Revert "debian: Remove isc-dhcp-client"

### DIFF
--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -1094,6 +1094,7 @@ packages:
     - init
     - iproute2
     - iputils-ping
+    - isc-dhcp-client
     - locales
     - netbase
     - net-tools


### PR DESCRIPTION
This breaks existing CIs using Debian images. In some setups the package is necessary in order to get networking to work, so it cannot be installed manually later, since the network is not up.
The package is still available so there's no reason to drop it for now. If it gets removed in a future release, then it can be moved to a release-specific section.

This reverts commit 3a729f9f8c0dfbe69ce3d4b4f6771186611f8974.