### PR TITLE
openwrt: fix architecture names

### DIFF
--- a/images/openwrt.yaml
+++ b/images/openwrt.yaml
@@ -149,7 +149,7 @@ actions:
   types:
     - vm
   architectures:
-    - x86_64
+    - x86-64
 
 - trigger: post-files
   action: |
@@ -159,7 +159,7 @@ actions:
   types:
     - vm
   architectures:
-    - aarch64
+    - armsr-armv8
 
 - trigger: post-files
   action: |


### PR DESCRIPTION
The names in the image.yaml are the ones after the architecture map has been applied, so it should be x86-64 and armsr-armv8 instead of x86_64 and aarch64.