### PR TITLE
test-image: use build-name plugin to expose image name

### DIFF
--- a/jenkins/jobs/test-image.yaml
+++ b/jenkins/jobs/test-image.yaml
@@ -49,3 +49,5 @@
     wrappers:
     - ansicolor:
         colormap: css
+    - build-name:
+        name: '#${BUILD_NUMBER} ${image}'


### PR DESCRIPTION
I don't have a jenkins server to try this on, but my working theory is the [build-name](https://jenkins-job-builder.readthedocs.io/en/latest/wrappers.html#wrappers.build_name) wrapper could maybe clarify which test is for which image. Assuming this theory is correct, and this ends up in the rss feed title, I can filter in my reader down to just nixos.

This will obviously require the plugin if not already installed. Thoughts?