### PR TITLE
Fix root= leak in /etc/kernel/cmdline for EL9 images

### DIFF
--- a/images/almalinux.yaml
+++ b/images/almalinux.yaml
@@ -449,6 +449,14 @@ actions:
     grub2-mkconfig -o "${target}"
     sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" "${target}"
 
+    # Update the default kernel command line, loop0p2 is still present there,
+    # which will be added by postinst scriptlets when installing or reinstalling
+    # a kernel. This fixes the rootfs mount on subsequent boots after upgrading
+    # the kernel.
+    if [ -f /etc/kernel/cmdline ]; then
+      sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" /etc/kernel/cmdline
+    fi
+
     # Update files in /boot/loader/entries/. `grubby` needs to be run after
     # `grub2-mkconfig` as the latter overwrites files in /boot/loader/entries/.
     grubby --update-kernel=/boot/vmlinuz-${kver} --args="root=${DISTROBUILDER_ROOT_UUID} ro"

--- a/images/centos.yaml
+++ b/images/centos.yaml
@@ -899,6 +899,14 @@ actions:
     grub2-mkconfig -o "${target}"
     sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" "${target}"
 
+    # Update the default kernel command line, loop0p2 is still present there,
+    # which will be added by postinst scriptlets when installing or reinstalling
+    # a kernel. This fixes the rootfs mount on subsequent boots after upgrading
+    # the kernel.
+    if [ -f /etc/kernel/cmdline ]; then
+      sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" /etc/kernel/cmdline
+    fi
+
     # Update files in /boot/loader/entries/. `grubby` needs to be run after
     # `grub2-mkconfig` as the latter overwrites files in /boot/loader/entries/.
     grubby --update-kernel=/boot/vmlinuz-${kver} --args="root=${DISTROBUILDER_ROOT_UUID} ro"

--- a/images/rockylinux.yaml
+++ b/images/rockylinux.yaml
@@ -437,6 +437,14 @@ actions:
     grub2-mkconfig -o "${target}"
     sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" "${target}"
 
+    # Update the default kernel command line, loop0p2 is still present there,
+    # which will be added by postinst scriptlets when installing or reinstalling
+    # a kernel. This fixes the rootfs mount on subsequent boots after upgrading
+    # the kernel.
+    if [ -f /etc/kernel/cmdline ]; then
+      sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" /etc/kernel/cmdline
+    fi
+
     # Update files in /boot/loader/entries/. `grubby` needs to be run after
     # `grub2-mkconfig` as the latter overwrites files in /boot/loader/entries/.
     grubby --update-kernel=/boot/vmlinuz-${kver} --args="root=${DISTROBUILDER_ROOT_UUID} ro"


### PR DESCRIPTION
The post-files action substitutes the build-time root device path in grub.cfg and BLS entries, but does not modify /etc/kernel/cmdline. That file is read by kernel-install during kernel package scriptlets, so any subsequent kernel install or reinstall regenerates the BLS entry with the leaked root path (e.g. /dev/loop0p2), breaking boot after the next kernel upgrade.

Apply the same root= substitution to /etc/kernel/cmdline so the seed file matches the BLS entries already in place.

Affects AlmaLinux 9, CentOS Stream 9, Rocky Linux 9. EL10 images do not ship /etc/kernel/cmdline.

fixes #976

I've built the image for almalinux locally and verified with a kernel reinstall, using images:almalinux/9 the kernel command line is changed to /dev/loop0p2, using this it no longer is changed. 
