### PR TITLE
openwrt: build type=container,vm by default

### DIFF
--- a/jenkins/jobs/image-openwrt.yaml
+++ b/jenkins/jobs/image-openwrt.yaml
@@ -36,9 +36,9 @@
         [ "$ARCH" = "amd64" ] && ARCH="x86_64"
         [ "$ARCH" = "arm64" ] && ARCH="aarch64"
 
-        TYPE="container"
-        if [ "$release" = "snapshot" ]; then
-          TYPE="container,vm"
+        TYPE="container,vm"
+        if [ "$release" = "24.10" ]; then
+          TYPE="container"
         fi
 
         PKGMANAGER="apk"


### PR DESCRIPTION
With the release of Openwrt 25.12.3, and thanks to the work of @rietbergenm, it should now be possible to build both container and vm images by default going forward. 

Change the default, with a container-only exception for 24.10.