### PR TITLE
opensuse: remove deprecated packages

### DIFF
--- a/images/opensuse.yaml
+++ b/images/opensuse.yaml
@@ -279,7 +279,6 @@ packages:
     - rsync
     - sudo
     - terminfo
-    - systemd-sysvinit
     - tar
     - which
     action: install
@@ -304,13 +303,6 @@ packages:
     - aarch64
     - x86_64
     - i686
-
-  - packages:
-    - net-tools
-    releases:
-    - tumbleweed
-    - 16.0
-    action: install
 
   - packages:
     - cloud-init


### PR DESCRIPTION
systemd-sysvcompat is gone with systemd 260.
net-tools has been deprecated for a long time.

This also fixes the build failures since tumbleweed fails to install systemd-sysvcompat.