### PR TITLE
Change the Oracle Linux mirror to a mirror which contains OL10.

### DIFF
--- a/images/oracle.yaml
+++ b/images/oracle.yaml
@@ -3,7 +3,7 @@ image:
 
 source:
   downloader: oraclelinux-http
-  url: https://mirrors.kernel.org/oracle/
+  url: https://ftp.icm.edu.pl/pub/Linux/dist/oracle-linux/
 
 targets:
   lxc:


### PR DESCRIPTION
The mirror on kernel.org doesn't have the Oracle Linux 10.