### PR TITLE
nixos: only repackage 25.11 images

### DIFF
--- a/jenkins/jobs/image-nixos.yaml
+++ b/jenkins/jobs/image-nixos.yaml
@@ -42,7 +42,7 @@
         # download a pre-built VM image
         curl --location --output $WORKSPACE/disk.qcow2 https://hydra.nixos.org/job/nixos/$JOBSET/nixos.incusVirtualMachineImage.$ARCH-linux/latest/download-by-type/file/qcow2-image
 
-        if [ "$RELEASE" = "unstable" ]; then
+        if [ "$RELEASE" != "25.11" ]; then
           # download a pre-built container rootfs
           curl --location --output $WORKSPACE/rootfs.squashfs https://hydra.nixos.org/job/nixos/$JOBSET/nixos.incusContainerImage.$ARCH-linux/latest/download-by-type/file/squashfs-image
 


### PR DESCRIPTION
The test to use the official images (#940) has been a success.

Therefore this can done for all images going forward.

At any point after 30.06.2026 we can clean this up while dropping 25.11.

cc @adamcstephens 