### PR TITLE
Add s390x to the ubuntu.yaml image file

### DIFF
--- a/images/ubuntu.yaml
+++ b/images/ubuntu.yaml
@@ -451,6 +451,7 @@ packages:
     - armhf
     - powerpc
     - powerpc64
+    - s390x
 
   - packages:
     - language-pack-en
@@ -553,6 +554,7 @@ packages:
     - powerpc64
     - ppc64el
     - riscv64
+    - s390x
 
 actions:
 - trigger: post-unpack


### PR DESCRIPTION
My team at IBM has been looking into using these images for Incus on Power and Z, but noted that only ppc64el was included, not s390x.