### PR TITLE
fedora: preserve vendor preset policy

### DIFF
--- a/images/fedora.yaml
+++ b/images/fedora.yaml
@@ -35,6 +35,13 @@ targets:
         lxc.arch = {{ image.architecture_kernel }}
 
 files:
+- path: /etc/systemd/system-preset/00-lxc-fedora.preset
+  generator: dump
+  content: |-
+    # Preserve image-selected network services across systemd first boot.
+    ignore systemd-resolved.service
+    ignore systemd-networkd.service
+
 - path: /etc/default/grub
   generator: dump
   content: |-
@@ -306,14 +313,6 @@ actions:
 
     systemctl enable systemd-resolved
     systemctl enable systemd-networkd
-
-    # Avoid being reset on reboot
-    rm -Rf /etc/systemd/system-preset
-    mkdir -p /etc/systemd/system-preset
-    for file in /usr/lib/systemd/system-preset/*; do
-        NAME=$(basename ${file})
-        ln -s /dev/null /etc/systemd/system-preset/${NAME}
-    done
 
     systemctl mask systemd-homed-firstboot.service || true
 


### PR DESCRIPTION
The Fedora image currently masks all vendor systemd preset files to keep image-selected network services enabled across first boot. That also removes Fedora's preset policy for newly installed packages, causing openssh-server to enable both sshd.service and sshd.socket. 

Add a local preset file that ignores only systemd-networkd and systemd-resolved, preserving those image-selected units while leaving Fedora vendor presets in place.

Fixes: https://github.com/lxc/lxc-ci/issues/998