### PR TITLE
jenkins/image-nixos: Remove 25.11

### DIFF
--- a/jenkins/jobs/image-nixos.yaml
+++ b/jenkins/jobs/image-nixos.yaml
@@ -19,7 +19,6 @@
         values:
         - unstable
         - 26.05
-        - 25.11
 
     - axis:
         name: variant
@@ -42,21 +41,14 @@
         # download a pre-built VM image
         curl --location --output $WORKSPACE/disk.qcow2 https://hydra.nixos.org/job/nixos/$JOBSET/nixos.incusVirtualMachineImage.$ARCH-linux/latest/download-by-type/file/qcow2-image
 
-        if [ "$RELEASE" != "25.11" ]; then
-          # download a pre-built container rootfs
-          curl --location --output $WORKSPACE/rootfs.squashfs https://hydra.nixos.org/job/nixos/$JOBSET/nixos.incusContainerImage.$ARCH-linux/latest/download-by-type/file/squashfs-image
+        # download a pre-built container rootfs
+        curl --location --output $WORKSPACE/rootfs.squashfs https://hydra.nixos.org/job/nixos/$JOBSET/nixos.incusContainerImage.$ARCH-linux/latest/download-by-type/file/squashfs-image
 
-          # download a pre-built incus metadata
-          curl --location --output $WORKSPACE/incus.tar.xz https://hydra.nixos.org/job/nixos/$JOBSET/nixos.incusContainerMeta.$ARCH-linux/latest/download-by-type/file/system-tarball
+        # download a pre-built incus metadata
+        curl --location --output $WORKSPACE/incus.tar.xz https://hydra.nixos.org/job/nixos/$JOBSET/nixos.incusContainerMeta.$ARCH-linux/latest/download-by-type/file/system-tarball
 
-          # write a serial used by publishing
-          date -u +%Y%m%d_%H:%M > $WORKSPACE/serial
-        else
-          exec sudo /lxc-ci/bin/build-distro /lxc-ci/images/nixos.yaml \
-              $INCUS_ARCHITECTURE container 14400 $WORKSPACE \
-              -o image.architecture=$ARCH \
-              -o image.release=$release
-        fi
+        # write a serial used by publishing
+        date -u +%Y%m%d_%H:%M > $WORKSPACE/serial
 
     properties:
     - build-discarder:


### PR DESCRIPTION
Hi, I'm the [Release Manager](https://nixos.org/community/teams/nixos-release/) of [NixOS 26.05 ("Yarara")](https://nixos.org/blog/announcements/2026/nixos-2605/).  

This PR removes the now unsupported 25.11 release, as part of my [end-of-life cleanup checklist](https://nixos.github.io/release-wiki/EOL-Cleanup.html).