### PR TITLE
openwrt: replace ifname with device in network config

### DIFF
--- a/images/openwrt.yaml
+++ b/images/openwrt.yaml
@@ -100,17 +100,17 @@ files:
   generator: dump
   content: |-
     config interface 'loopback'
-        option ifname 'lo'
+        option device 'lo'
         option proto 'static'
         option ipaddr '127.0.0.1'
         option netmask '255.0.0.0'
 
     config interface 'wan'
-        option ifname 'eth0'
+        option device 'eth0'
         option proto 'dhcp'
 
     config interface 'wan6'
-        option ifname 'eth0'
+        option device 'eth0'
         option proto 'dhcpv6'
 
     config globals 'globals'


### PR DESCRIPTION
OpenWrt 21.02 renamed the interface-level `ifname` option in `config interface` to `device`.

The old syntax is still supported for backward compatibility, but when LuCI detects it, it offers to migrate the network configuration to the new syntax before allowing normal editing through the UI.

Generate the current syntax directly by using `device` instead of `ifname`.

This matches the current image generation path, which targets OpenWrt 24.x and newer.

Reference:
https://openwrt.org/releases/21.02/notes-21.02.0#new_network_configuration_syntax_and_boardjson_change