### PR TITLE
openwrt: chmod +x 00-incus-set-hostname

### DIFF
--- a/images/openwrt.yaml
+++ b/images/openwrt.yaml
@@ -88,6 +88,7 @@ files:
 - name: uci-defaults-hostname.incus
   path: /etc/uci-defaults/00-incus-set-hostname
   generator: template
+  mode: 0755
   template:
     when:
       - create


### PR DESCRIPTION
The `uci-defaults` file that sets a hostname on boot does not appear to work at present. Add a `mode:` line to set the execute bit.