### PR TITLE
alpine: support IPv6 in Alpine Edge VM images

### DIFF
--- a/images/alpine.yaml
+++ b/images/alpine.yaml
@@ -232,6 +232,7 @@ files:
   content: |-
     auto eth0
     iface eth0 inet dhcp
+    iface eth0 inet6 dhcp
     hostname $(hostname)
 
 - path: /etc/inittab
@@ -330,6 +331,7 @@ packages:
     - acpi
     - grub-efi
     - linux-virt
+    - dhcpcd
     action: install
     types:
     - vm


### PR DESCRIPTION
Add dhcpcd package and line in /etc/network/interfaces so Alpine Edge VMs have working IPv6 connectivity.