### PR TITLE
alpine: use dhcpcd for IP address management

### DIFF
--- a/images/alpine.yaml
+++ b/images/alpine.yaml
@@ -235,6 +235,56 @@ files:
     iface eth0 inet6 dhcp
     hostname $(hostname)
 
+- path: /etc/dhcpcd.conf
+  generator: dump
+  content: |-
+    # A sample configuration for dhcpcd.
+    # See dhcpcd.conf(5) for details.
+
+    # Allow users of this group to interact with dhcpcd via the control socket.
+    #controlgroup wheel
+
+    # Inform the DHCP server of our hostname for DDNS.
+    #hostname
+
+    # Use the hardware address of the interface for the Client ID.
+    #clientid
+    # or
+    # Use the same DUID + IAID as set in DHCPv6 for DHCPv4 ClientID as per RFC4361.
+    # Some non-RFC compliant DHCP servers do not reply with this set.
+    # In this case, comment out duid and enable clientid above.
+    duid
+
+    # Persist interface configuration when dhcpcd exits.
+    persistent
+
+    # vendorclassid is set to blank to avoid sending the default of
+    # dhcpcd-<version>:<os>:<machine>:<platform>
+    vendorclassid
+
+    # A list of options to request from the DHCP server.
+    option domain_name_servers, domain_name, domain_search
+    option static_routes, classless_static_routes
+    # Respect the network MTU. This is applied to DHCP routes.
+    option interface_mtu
+
+    # Request a hostname from the network
+    option host_name
+
+    # Most distributions have NTP support.
+    #option ntp_servers
+
+    # A ServerID is required by RFC2131.
+    require dhcp_server_identifier
+
+    # Generate SLAAC address using the Hardware Address of the interface
+    slaac hwaddr
+    # OR generate Stable Private IPv6 Addresses based from the DUID
+    #slaac private
+
+    # Do not generate a RFC 3927 IPv4 link-local address when DHCPv4 fails
+    noipv4ll
+
 - path: /etc/inittab
   generator: dump
   content: |-
@@ -311,6 +361,7 @@ packages:
     - alpine-base
     - logrotate
     - doas
+    - dhcpcd
     action: install
 
   - packages:


### PR DESCRIPTION
This integrates Alpine Linux instances properly into an Incus managed network:

* with `ipv4.address=none`, no IPv4 address is configured
* with `ipv6.address=none`, only a link-local IPv6 address is configured
* with `ipv4.address` set, an IPv4 address is obtained via DHCPv4
* with `ipv6.address` set, an IPv6 SLAAC address based on the hardware address is configured
* with `ipv6.dhcp.stateful=true`, and additional IPv6 address is obtained via DHCPv6
* DNS name server(s) are configured from to DHCPv4, DHCPv6 and RDNSS