### PR TITLE
images/debian: Only add incus-growpart.service to debian default variant

### DIFF
--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -1430,6 +1430,8 @@ actions:
     systemctl enable incus-growpart
   types:
   - vm
+  variants:
+  - default
 
 - trigger: post-files
   action: |-


### PR DESCRIPTION
The cloud images perform the part grow and resizefs via cloud-init.
The ubuntu cloud image already reflects this.
This PR removed the incus-growpart service from the debian image as well.