### PR TITLE
images/arch: Add hostname template target in post unpack stage

### DIFF
--- a/images/archlinux.yaml
+++ b/images/archlinux.yaml
@@ -239,6 +239,13 @@ actions:
 - trigger: post-unpack
   action: |-
     #!/bin/sh
+    # Make sure we have our template targets
+    touch /etc/hosts
+    touch /etc/hostname
+
+- trigger: post-unpack
+  action: |-
+    #!/bin/sh
     set -eux
 
     echo 'Server = https://mirror.csclub.uwaterloo.ca/archlinux/$repo/os/$arch' > /etc/pacman.d/mirrorlist


### PR DESCRIPTION
The arch image is missing the /etc/hostname file, so incus does not have a template target.